### PR TITLE
Fix Windows start menu icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "screendeck",
     "version": "2.0.0",
     "author": "Joseph Adams <joseph@josephadams.dev>",
-    "description": "ScreenDeck is a virtual on-screen stream deck for Bitfocus Companion, built with Electron and TypeScript. This application allows you to create a customizable keypad interface that can send button presses to Companion, enabling you to control various applications, and perform automated tasks, all from an easily accessible on-screen interface.",
+    "description": "ScreenDeck is a virtual on-screen stream deck for Bitfocus Companion.",
     "main": "dist/main.js",
     "scripts": {
         "start": "yarn build && electron .",


### PR DESCRIPTION
Resolves #12.

The app description field seems to be too long for the shortcut created during a Windows install by NSIS. I can't see a way of creating a Windows only description, so unless you want to write an alternative [custom NSIS install script](https://www.electron.build/nsis.html#custom-nsis-script), the best solution seems to be to shorten the main decription in `package.json`

I've shortened it to the first key phrase, but I suspect any string up to 259 characters will work.

Here's my installation after implementing this change (available [here](https://github.com/Xcodo/screendeck/releases/tag/v0.999.3)):
![image](https://github.com/user-attachments/assets/9bea4021-0286-4930-986d-c5a745a570f4)
![image](https://github.com/user-attachments/assets/a7043f28-1381-4a5c-a3f4-d5b93ee1cba0)
![image](https://github.com/user-attachments/assets/7740dcd1-8a07-4982-a05e-be1b56ea5d8f)
