### PR TITLE
fix: tray visibility persistence, quit flow, and duplicate device-add race

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -658,7 +658,7 @@ export class CompanionSatelliteClient
         }
 
         const pendingTime = this._pendingDevices.get(deviceId)
-        if (pendingTime && pendingTime < Date.now() - 10000) {
+        if (pendingTime && pendingTime > Date.now() - 10000) {
             throw new Error('Device is already being added')
         }
 

--- a/src/device.ts
+++ b/src/device.ts
@@ -106,6 +106,9 @@ export function createDeviceWindow(deviceId: string) {
         updateTrayMenu()
     })
     win.on('close', (event) => {
+        if (global.isQuitting) {
+            return
+        }
         event.preventDefault() // Prevent default close behavior
         win.hide() // Hide the window instead of closing it
         win.webContents.send('windowClosed', { deviceId })

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,6 +36,7 @@ declare global {
     >
     var trayParentWindow: BrowserWindow
     var settingsWindow: BrowserWindow | null
+    var isQuitting: boolean
 }
 
 // Initialize the Companion Satellite client and device windows
@@ -47,6 +48,7 @@ function init() {
     global.hotkeyContext = null
     global.registeredHotkeys = new Map()
     global.settingsWindow = null
+    global.isQuitting = false
 
     global.trayParentWindow = new BrowserWindow({
         show: false,

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -63,10 +63,10 @@ function updateTrayMenu() {
             label: `Hide All Screen Decks`,
             type: 'normal',
             click: () => {
-                global.deviceWindows.forEach((win) => {
+                global.deviceWindows.forEach((win, deviceId) => {
                     if (win.isVisible()) {
                         win.hide()
-                        store.set(`device.${win.webContents.id}.hidden`, true)
+                        store.set(`device.${deviceId}.hidden`, true)
                     }
                 })
                 updateTrayMenu()
@@ -76,10 +76,10 @@ function updateTrayMenu() {
             label: `Show All Screen Decks`,
             type: 'normal',
             click: () => {
-                global.deviceWindows.forEach((win) => {
+                global.deviceWindows.forEach((win, deviceId) => {
                     if (!win.isVisible()) {
                         win.show()
-                        store.set(`device.${win.webContents.id}.hidden`, false)
+                        store.set(`device.${deviceId}.hidden`, false)
                     }
                 })
                 updateTrayMenu()
@@ -191,6 +191,8 @@ function updateTrayMenu() {
             label: 'Quit',
             type: 'normal',
             click: () => {
+                global.isQuitting = true
+
                 // Disconnect Companion client
                 if (global.satelliteClient) {
                     global.satelliteClient.disconnect() // or .disconnect() based on your API
@@ -211,11 +213,6 @@ function updateTrayMenu() {
 
                 // Quit the app
                 app.quit()
-
-                setTimeout(() => {
-                    console.log('Force exiting app...')
-                    process.exit(0)
-                }, 1000)
             },
         },
         { type: 'separator' },


### PR DESCRIPTION
## Summary
- **Tray Hide/Show All**: the click handlers stored hidden state under `device.${win.webContents.id}.hidden`, using Electron's internal numeric `webContents.id` instead of the app's `deviceId` string key that `showWindows()` (and every other call site) reads/writes. Persisted state from "Hide All"/"Show All" was therefore never honored on restart. Fixed both handlers to destructure `deviceId` from the `deviceWindows` Map and use it as the store key.
- **Quit flow**: the device window `close` handler always called `event.preventDefault()` and hid the window, even during an intentional quit, so `app.quit()` could never actually finish (no window ever really closed). This was papered over with a `setTimeout(() => process.exit(0), 1000)` that bypassed Electron's normal shutdown lifecycle. Added a proper `global.isQuitting` flag (declared/initialized in `src/main.ts`) that's set at the very start of the Quit menu handler; the `close` handler now lets the close proceed when quitting, so `app.quit()` completes normally, and the `process.exit(0)` band-aid was removed.
- **Duplicate device-add race**: `CompanionSatelliteClient.addDevice()`'s staleness check on `_pendingDevices` was inverted — it threw "Device is already being added" for *stale* entries (>10s old) and silently allowed a duplicate add through while a request was genuinely still in-flight (<10s old). Flipped the comparison so a fresh pending entry correctly blocks the duplicate.

## Test plan
- [x] `tsc` (`yarn build`) compiles with no errors
- [x] Manually traced `tray.ts` Hide All/Show All against `device.ts`'s `showWindows()` to confirm the store key now matches
- [x] Manually traced the quit path: `isQuitting` set → `win.close()` skips `preventDefault` → windows actually close → `app.quit()` can complete without the forced `process.exit`
- [x] Confirmed the `addDevice` staleness comparison now rejects a duplicate add while pending (<10s) and allows a fresh add after a stale (>10s) pending entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)