### PR TITLE
Fix hotkey image preview, orphaned device hotkeys, and silent assign failures

### DIFF
--- a/public/hotkeyPrompt.html
+++ b/public/hotkeyPrompt.html
@@ -43,6 +43,13 @@
                 margin-top: 20px;
             }
 
+            .hotkey-error {
+                color: #c0392b;
+                margin: 10px 0;
+                font-size: 0.9em;
+                min-height: 1.2em;
+            }
+
             .close-button-settings {
                 -webkit-app-region: no-drag;
                 position: absolute;
@@ -81,6 +88,7 @@
             placeholder="Enter key (e.g., A, 1)"
         />
         <div class="hotkey-preview" id="hotkeyPreview"></div>
+        <div class="hotkey-error" id="hotkeyError"></div>
 
         <button id="assignHotkey">Assign Hotkey</button>
         <button id="cancel">Cancel</button>

--- a/public/hotkeyPrompt.js
+++ b/public/hotkeyPrompt.js
@@ -3,6 +3,23 @@ window.addEventListener('DOMContentLoaded', () => {
     let primaryKey = ''
     let deviceId = ''
     let keyIndex = ''
+    let currentHotkeys = []
+
+    function showHotkeyError(message) {
+        const errorEl = document.getElementById('hotkeyError')
+        if (errorEl) {
+            errorEl.textContent = message
+        } else {
+            alert(message)
+        }
+    }
+
+    function clearHotkeyError() {
+        const errorEl = document.getElementById('hotkeyError')
+        if (errorEl) {
+            errorEl.textContent = ''
+        }
+    }
 
     // Get initial data
     window.electronAPI.invoke('getHotkeyContext').then((data) => {
@@ -51,6 +68,8 @@ window.addEventListener('DOMContentLoaded', () => {
     }
 
     function updateHotkeyList(hotkeys) {
+        currentHotkeys = hotkeys || []
+
         const tbody = document.getElementById('hotkeyList')
         tbody.innerHTML = ''
 
@@ -106,6 +125,8 @@ window.addEventListener('DOMContentLoaded', () => {
     }
 
     document.getElementById('assignHotkey').addEventListener('click', () => {
+        clearHotkeyError()
+
         if (!primaryKey) {
             alert('Please enter a key')
             return
@@ -120,14 +141,35 @@ window.addEventListener('DOMContentLoaded', () => {
 
         const hotkeyStr = Array.from(modifiers).join('+') + `+${primaryKey}`
 
+        // Proactively check for conflicts with other keys/devices before
+        // even asking the main process to register the hotkey.
+        const conflict = currentHotkeys.find(
+            (h) =>
+                h.hotkey === hotkeyStr &&
+                (h.deviceId !== deviceId || h.keyIndex !== keyIndex)
+        )
+
+        if (conflict) {
+            showHotkeyError(
+                `${hotkeyStr} is already assigned to key ${conflict.keyIndex} on ${conflict.deviceId}`
+            )
+            return
+        }
+
         window.electronAPI
             .invoke('assignHotkey', {
                 deviceId,
                 keyIndex,
                 hotkey: hotkeyStr,
             })
-            .then(() => {
-                window.close()
+            .then((success) => {
+                if (success) {
+                    window.close()
+                } else {
+                    showHotkeyError(
+                        `${hotkeyStr} could not be assigned. It may already be in use.`
+                    )
+                }
             })
     })
 

--- a/src/hotkeys.ts
+++ b/src/hotkeys.ts
@@ -43,7 +43,7 @@ export function registerHotkey(
         global.registeredHotkeys.set(hotkey, {
             deviceId,
             keyIndex,
-            imageBase64: '',
+            imageBase64,
         })
         console.log(
             `Registered hotkey: ${hotkey} for ${deviceId} key ${keyIndex}`

--- a/src/ipcHandlers.ts
+++ b/src/ipcHandlers.ts
@@ -5,7 +5,11 @@ import { defaultSettings } from './defaults'
 import { createSatellite, getNextProfileName } from './utils'
 import { updateTrayMenu } from './tray'
 
-import { registerHotkey, unregisterHotkey } from './hotkeys' // Import the hotkey registration function
+import {
+    registerHotkey,
+    unregisterHotkey,
+    unregisterAllHotkeysForDevice,
+} from './hotkeys' // Import the hotkey registration function
 import {
     createNewDevice,
     createDeviceWindow,
@@ -467,6 +471,9 @@ export function initializeIpcHandlers() {
                 store.delete(key as any)
             }
         })
+
+        // Unregister any global hotkeys associated with this device
+        unregisterAllHotkeysForDevice(deviceId)
 
         // Close the window
         const win = global.deviceWindows.get(deviceId)


### PR DESCRIPTION
## Summary
- `registerHotkey` in `src/hotkeys.ts` was looking up the key's `imageBase64` but then hardcoding `imageBase64: ''` in the stored mapping, so `loadHotkeysFromStore()` on app start always produced blank previews for previously-assigned hotkeys in the Assign Hotkey dialog's hotkey list. Now uses the looked-up value.
- `deleteDevice` in `src/ipcHandlers.ts` cleaned up store keys, the device window, and the satellite client, but never released the device's global OS-level hotkeys, leaving them registered (and blocking those key combos) even after the device was deleted. Now calls the existing `unregisterAllHotkeysForDevice(deviceId)` helper from `src/hotkeys.ts`.
- `public/hotkeyPrompt.js`'s Assign button ignored the boolean result of the `assignHotkey` IPC call and always closed the dialog, so a failed assignment (e.g. hotkey already registered) silently looked successful. It now checks the result and only closes on success, showing an inline error otherwise.
- Added proactive conflict feedback: before calling `assignHotkey`, the renderer now checks the `currentHotkeys` list already returned by `getHotkeyContext` for a matching hotkey on a different device/key, and if found shows a specific message (e.g. "Ctrl+Shift+A is already assigned to key 3 on screendeck-abc123") instead of round-tripping to the main process. The result-check fix remains as a safety net for races.

## Test plan
- [x] `yarn build` compiles with no new TypeScript errors.
- [ ] Manually verify: assign a hotkey to a key, restart the app, open the Assign Hotkey dialog for that key — the preview image for it should now render instead of being blank.
- [ ] Manually verify: delete a device that has an assigned global hotkey, then confirm the same key combo can be re-registered on another device without electron reporting "already in use".
- [ ] Manually verify: in the Assign Hotkey dialog, try to assign a hotkey combo that's already used by another key — should show an inline message identifying the conflicting device/key instead of silently closing or alerting generically.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>