### PR TITLE
Restore device visibility settings UI and wire up window resize

### DIFF
--- a/public/settings.js
+++ b/public/settings.js
@@ -142,8 +142,8 @@ window.addEventListener('DOMContentLoaded', () => {
                 alwaysOnTopInput,
                 movableInput,
                 disablePressInput,
-                //autoHideInput,
-                //hideEmptyKeysInput,
+                autoHideInput,
+                hideEmptyKeysInput,
             ].forEach((inputObj) => {
                 rightFields.appendChild(inputObj.label)
                 rightFields.appendChild(inputObj.input)
@@ -173,8 +173,8 @@ window.addEventListener('DOMContentLoaded', () => {
                     alwaysOnTop: alwaysOnTopInput.input.checked,
                     movable: movableInput.input.checked,
                     disablePress: disablePressInput.input.checked,
-                    //autoHide: autoHideInput.input.checked,
-                    //hideEmptyKeys: hideEmptyKeysInput.input.checked,
+                    autoHide: autoHideInput.input.checked,
+                    hideEmptyKeys: hideEmptyKeysInput.input.checked,
                     backgroundColor: backgroundColorInput.value,
                     backgroundOpacity: parseFloat(backgroundOpacityInput.value),
                 }

--- a/src/ipcHandlers.ts
+++ b/src/ipcHandlers.ts
@@ -371,7 +371,7 @@ export function initializeIpcHandlers() {
                 win.webContents.send('autoHide', Boolean(config.autoHide))
             }
             if (config.hideEmptyKeys !== undefined) {
-                //resizeWindowForDevice(deviceId)
+                resizeWindowForDevice(deviceId)
                 win.webContents.send(
                     'hideEmptyKeys',
                     Boolean(config.hideEmptyKeys)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ import ShortUniqueId from 'short-uuid'
 import { defaultSettings } from './defaults' // Your settings file
 import path from 'path'
 import { createNewDevice, createDeviceWindows, showWindows } from './device' // Function to create a new device
+import { resizeWindowForDevice } from './device'
 import { CompanionSatelliteClient } from './client' // Your new client class
 import { updateTrayMenu } from './tray'
 import { ProfilesStore, Profile } from './types' // Import your types
@@ -102,7 +103,7 @@ export function createSatellite() {
         // Send the draw event to the corresponding device window
         const win = global.deviceWindows.get(data.deviceId)
         if (win) {
-            //resizeWindowForDevice(data.deviceId)
+            resizeWindowForDevice(data.deviceId)
             win.webContents.send('draw', data)
         }
     })


### PR DESCRIPTION
## Summary
- Restores the "Auto Hide on Mouse Leave" and "Hide Empty Keys" checkboxes in the Settings window (`public/settings.js`) — they were already built via `createCheckbox(...)` but were commented out of both the rendered field list and the Save handler's persisted config, making them dead code with no way to toggle them from the UI.
- Wires up `resizeWindowForDevice` (`src/device.ts`), a fully-implemented but previously unreachable function that shrinks/grows a device window to fit only its populated keys when `hideEmptyKeys` is enabled. It's now called from:
  - `src/utils.ts` — on each Companion Satellite `draw` event, so the window live-resizes as keys populate.
  - `src/ipcHandlers.ts` — in the `updateDeviceConfig` handler, when `hideEmptyKeys` is toggled from Settings.

No other behavior was changed; `resizeWindowForDevice`'s implementation itself is untouched, only its call sites were uncommented.

Note: this touches `public/settings.js`, which may already be under active development elsewhere — a manual rebase may be needed if it conflicts with other in-flight settings.js changes.

## Test plan
- [x] `yarn build` (`tsc`) compiles with no errors.
- [ ] Open Settings, confirm both "Auto Hide on Mouse Leave" and "Hide Empty Keys" checkboxes render, can be toggled, and persist after Save + reopening Settings.
- [ ] With `hideEmptyKeys` enabled for a device, confirm its window shrinks/grows as Companion sends key draws (populating/clearing keys should resize the window to fit only populated keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)