### PR TITLE
Fix five code-quality issues from review

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -1,7 +1,14 @@
 // Helper function to convert hex + opacity to rgba
 function hexToRgba(hex, opacity) {
     if (!hex) return `rgba(0,0,0,${opacity})`
-    const bigint = parseInt(hex.replace('#', ''), 16)
+    let clean = hex.replace('#', '')
+    if (clean.length === 3) {
+        clean = clean.split('').map((c) => c + c).join('')
+    }
+    if (!/^[0-9a-fA-F]{6}$/.test(clean)) {
+        return `rgba(0,0,0,${opacity})`
+    }
+    const bigint = parseInt(clean, 16)
     const r = (bigint >> 16) & 255
     const g = (bigint >> 8) & 255
     const b = bigint & 255
@@ -186,7 +193,7 @@ window.addEventListener('DOMContentLoaded', () => {
         const keypad = document.getElementById('keypad')
         globalColumnCount = columnCount
         globalRowCount = rowCount
-        keysTotal = columnCount * rowCount
+        let keysTotal = columnCount * rowCount
 
         keypad.style.gridTemplateColumns = `repeat(${columnCount}, 1fr)`
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -709,7 +709,10 @@ export class CompanionSatelliteClient
             } else if (typeof value === 'number') {
                 valueStr = value.toString()
             } else {
-                valueStr = `"${value}"`
+                const escaped = String(value)
+                    .replace(/\\/g, '\\\\')
+                    .replace(/"/g, '\\"')
+                valueStr = `"${escaped}"`
             }
             chunks.push(`${key}=${valueStr}`)
         }

--- a/src/ipcHandlers.ts
+++ b/src/ipcHandlers.ts
@@ -127,12 +127,24 @@ export function initializeIpcHandlers() {
     ipcMain.handle(
         'updateKeyConfig',
         (_event, { deviceId, keyIndex, config }) => {
-            const isEncoder = config.isEncoder ?? false
-            const stepSize = config.stepSize ?? 10
-            const isSticky = config.isSticky ?? false
-            store.set(`device.${deviceId}.key.${keyIndex}.isEncoder`, isEncoder)
-            store.set(`device.${deviceId}.key.${keyIndex}.stepSize`, stepSize)
-            store.set(`device.${deviceId}.key.${keyIndex}.isSticky`, isSticky)
+            const existing = {
+                isEncoder: store.get(
+                    `device.${deviceId}.key.${keyIndex}.isEncoder`,
+                    false
+                ),
+                stepSize: store.get(
+                    `device.${deviceId}.key.${keyIndex}.stepSize`,
+                    10
+                ),
+                isSticky: store.get(
+                    `device.${deviceId}.key.${keyIndex}.isSticky`,
+                    false
+                ),
+            }
+            const merged = { ...existing, ...config }
+            store.set(`device.${deviceId}.key.${keyIndex}.isEncoder`, merged.isEncoder)
+            store.set(`device.${deviceId}.key.${keyIndex}.stepSize`, merged.stepSize)
+            store.set(`device.${deviceId}.key.${keyIndex}.isSticky`, merged.isSticky)
         }
     )
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -284,40 +284,6 @@ export function loadProfile(profileId: string) {
     //restart the app
     app.relaunch()
     app.exit(0)
-
-    /*
-    // Recreate device windows
-    createDeviceWindows()
-    const deviceIds = store.get('deviceIds', []) as string[]
-    console.log(`Recreating windows for devices: ${deviceIds.join(', ')}`)
-    for (const deviceId of deviceIds) {
-        console.log(`[Satellite] Adding device: ${deviceId}`)
-        global.satelliteClient?.addDevice(deviceId, 'ScreenDeck', {
-            columnCount: store.get(`device.${deviceId}.columnCount`, 8),
-            rowCount: store.get(`device.${deviceId}.rowCount`, 4),
-            bitmapSize: store.get(`device.${deviceId}.bitmapSize`, 72),
-            colours: true,
-            text: true,
-            brightness: true,
-            pincodeMap: null,
-        })
-    }
-
-    showWindows()
-
-    //register hotkeys for the new devices
-    loadHotkeysFromStore()
-
-    console.log(`Profile "${profileName}" loaded.`)
-
-    showNotification(
-        'Profile Loaded',
-        `Profile "${profileName}" has been loaded successfully.`
-    )
-
-    store.set('currentProfile', profileId)
-
-    updateTrayMenu()*/
 }
 
 export function deleteProfile(profileId: string) {


### PR DESCRIPTION
## Summary
- `updateKeyConfig` in `src/ipcHandlers.ts` now reads the existing stored key config and merges the incoming partial `config` on top of it, instead of resetting any field the caller omitted back to a hardcoded default.
- `sendMessage` in `src/client.ts` now escapes backslashes and double quotes before wrapping string protocol values in quotes, so values containing those characters round-trip correctly through the backslash-aware `parseLineParameters`.
- `hexToRgba` in `public/index.js` now normalizes 3-digit shorthand hex colors to 6-digit, validates the format with a regex, and falls back to black on anything invalid instead of silently producing a wrong color.
- `keysTotal` in `buildKeyGrid` (`public/index.js`) is now declared with `let` instead of being an implicit global in the non-strict script. Confirmed via grep it's only read/written within `buildKeyGrid`.
- Removed ~30 lines of dead, unreachable commented-out code at the end of `loadProfile` in `src/utils.ts` (an old pre-relaunch reload path superseded by `app.relaunch()` / `app.exit(0)`).

No unrelated code was touched, and `CODE_REVIEW.md` was not modified.

## Test plan
- [x] `yarn build` (`tsc`) compiles with no errors
- [ ] Manually verify key config updates preserve unspecified fields (e.g. toggling encoder mode doesn't reset step size)
- [ ] Manually verify Satellite protocol messages with quotes/backslashes in variable values parse correctly on the receiving side
- [ ] Manually verify key grid rendering still works after the `keysTotal` scoping fix