### PR TITLE
Add Companion connection status indicator to device windows

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,6 +17,11 @@
             <button id="closeButton" class="close-button">×</button>
             <div id="lockIndicator" class="lock-indicator">🔒</div>
             <div id="device-label" class="device-label"></div>
+            <div
+                id="connectionStatus"
+                class="connection-status"
+                title="Companion connection status"
+            ></div>
 
             <!-- The main content area -->
             <div id="keypad" class="keypad">

--- a/public/index.js
+++ b/public/index.js
@@ -627,6 +627,15 @@ window.addEventListener('DOMContentLoaded', () => {
         adjustBrightness(brightness)
     })
 
+    // Handle Companion connection status changes
+    window.electronAPI.onSatelliteStatus((_, status) => {
+        const indicator = document.getElementById('connectionStatus')
+        if (indicator) {
+            indicator.classList.remove('connecting', 'connected', 'disconnected')
+            indicator.classList.add(status)
+        }
+    })
+
     // Close button
     document.getElementById('closeButton').addEventListener('click', () => {
         window.electronAPI.invoke('closeKeypad', deviceId) // Send deviceId so main process knows which to close

--- a/public/styles.css
+++ b/public/styles.css
@@ -295,6 +295,34 @@ input[type='color'] {
     display: block;
 }
 
+/* Companion connection status indicator */
+.connection-status {
+    -webkit-app-region: no-drag;
+    position: absolute;
+    bottom: 5px;
+    right: 5px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.2);
+    box-shadow: 0 0 2px rgba(0, 0, 0, 0.6);
+    z-index: 100;
+    cursor: default;
+    transition: background-color 0.2s ease;
+}
+
+.connection-status.connected {
+    background: #4caf50;
+}
+
+.connection-status.connecting {
+    background: #ffc107;
+}
+
+.connection-status.disconnected {
+    background: #f44336;
+}
+
 .keypad.identify-highlight {
     outline: 3px solid yellow;
     box-shadow: 0 0 30px 10px rgba(255, 255, 0, 0.8);

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -65,6 +65,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.on('lockedState', (event, data) => callback(event, data))
     },
 
+    // Listen for Companion satellite connection status changes
+    onSatelliteStatus: (callback: any) => {
+        ipcRenderer.on('satelliteStatus', (event, status) =>
+            callback(event, status)
+        )
+    },
+
     // Get per-device config (columnCount, rowCount, etc.)
     getDeviceConfig: (deviceId: string) =>
         ipcRenderer.invoke('getDeviceConfig', deviceId),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -64,7 +64,23 @@ export function createSatellite() {
 
             updateTrayMenu()
             showWindows()
+
+            global.deviceWindows.forEach((win) => {
+                win.webContents.send('satelliteStatus', 'connected')
+            })
         }, 500)
+    })
+
+    global.satelliteClient.on('connecting', () => {
+        global.deviceWindows.forEach((win) => {
+            win.webContents.send('satelliteStatus', 'connecting')
+        })
+    })
+
+    global.satelliteClient.on('disconnected', () => {
+        global.deviceWindows.forEach((win) => {
+            win.webContents.send('satelliteStatus', 'disconnected')
+        })
     })
 
     global.satelliteClient.on('draw', (data) => {


### PR DESCRIPTION
## Summary
- Broadcasts the `CompanionSatelliteClient`'s `connecting`/`connected`/`disconnected` events from `createSatellite()` (src/utils.ts) to every open device window via a new `satelliteStatus` IPC message.
- Adds `onSatelliteStatus` to the preload bridge (src/preload.ts).
- Adds a small `#connectionStatus` dot to each device window (public/index.html), styled in public/styles.css with distinct colors for connected (green), connecting (yellow), and disconnected (red), positioned unobtrusively in the bottom-right corner of the window.
- Wires the renderer (public/index.js) to update the indicator's class on `satelliteStatus` events.

This lets users see Companion connectivity at a glance on each device window instead of having to open the tray menu.

Note: device windows created after the client already connected/disconnected won't retroactively receive that state — same limitation as other existing per-connection push events (e.g. `brightness`).

## Test plan
- [ ] `yarn build` compiles with no errors (verified locally).
- [ ] Start the app with Companion unreachable (wrong IP/port or Companion not running) and confirm device windows show the "connecting" (yellow) then "disconnected" (red) indicator.
- [ ] Start/point Companion at the configured address and confirm the indicator flips to "connected" (green) on each open device window.