### PR TITLE
Add step size and clear sticky mode context menu items

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -283,8 +283,10 @@ window.addEventListener('DOMContentLoaded', () => {
         menu.style.position = 'fixed'
         menu.innerHTML = `
     <div class="menu-item" data-action="encoder">Set to Encoder Mode</div>
+    <div class="menu-item" data-action="set-step-size">Set Step Size...</div>
     <div class="menu-item" data-action="button">Set to Button Mode (Normal)</div>
     <div class="menu-item" data-action="button-sticky">Set to Sticky Button Mode</div>
+    <div class="menu-item" data-action="clear-sticky">Clear Sticky Mode</div>
     <div class="menu-item" data-action="hotkey">Assign Hotkey...</div>
     `
 
@@ -345,6 +347,48 @@ window.addEventListener('DOMContentLoaded', () => {
                         config: { isEncoder: false, isSticky: true },
                     })
                     .then(() => refreshKey(deviceId, keyIndex))
+            } else if (action === 'set-step-size') {
+                window.electronAPI
+                    .invoke('getKeyConfig', { deviceId, keyIndex })
+                    .then((current) => {
+                        const input = prompt(
+                            'Enter step size (degrees per notch):',
+                            current.stepSize || 10
+                        )
+                        if (input === null) return
+                        const stepSize = parseInt(input, 10)
+                        if (isNaN(stepSize) || stepSize <= 0) {
+                            alert('Please enter a positive whole number.')
+                            return
+                        }
+                        window.electronAPI
+                            .invoke('updateKeyConfig', {
+                                deviceId,
+                                keyIndex,
+                                config: {
+                                    isEncoder: current.isEncoder,
+                                    isSticky: current.isSticky,
+                                    stepSize,
+                                },
+                            })
+                            .then(() => refreshKey(deviceId, keyIndex))
+                    })
+            } else if (action === 'clear-sticky') {
+                window.electronAPI
+                    .invoke('getKeyConfig', { deviceId, keyIndex })
+                    .then((current) => {
+                        window.electronAPI
+                            .invoke('updateKeyConfig', {
+                                deviceId,
+                                keyIndex,
+                                config: {
+                                    isEncoder: current.isEncoder,
+                                    isSticky: false,
+                                    stepSize: current.stepSize,
+                                },
+                            })
+                            .then(() => refreshKey(deviceId, keyIndex))
+                    })
             } else if (action === 'hotkey') {
                 let keyConfig = keyStates.get(deviceId)?.get(keyIndex)
                 let imageBase64 = keyConfig?.imageBase64 || null


### PR DESCRIPTION
## Summary
- Add a "Set Step Size..." context menu item (right after "Set to Encoder Mode") that prompts for a custom encoder step size (degrees per notch), validates it's a positive whole number, and saves it.
- Add a "Clear Sticky Mode" context menu item (right after "Set to Sticky Button Mode") that turns sticky mode off without requiring the user to re-select "Set to Button Mode (Normal)".
- Both new actions first call `getKeyConfig` to fetch the key's full current config, then pass all three fields (`isEncoder`, `isSticky`, `stepSize`) back into `updateKeyConfig`, so they don't accidentally reset unrelated fields — `updateKeyConfig` currently overwrites all three fields on every call regardless of which ones were passed in.

## Test plan
- [ ] Right-click a key, choose "Set to Encoder Mode" to make it an encoder.
- [ ] Right-click the same key, choose "Set Step Size...", enter a custom value (e.g. 20), confirm the prompt saves and `refreshKey` re-renders without resetting the key back to non-encoder mode.
- [ ] Try "Set Step Size..." with invalid input (blank/zero/negative/non-numeric) and confirm it's rejected via the alert and no config change happens.
- [ ] Right-click a key, choose "Set to Sticky Button Mode", confirm the sticky class/behavior is applied.
- [ ] Right-click the same key, choose "Clear Sticky Mode", confirm the sticky class/behavior is removed while the key's encoder/step-size settings are left untouched.
- [ ] Run `yarn build` to confirm the TypeScript build still passes (no changes needed there — this PR only touches `public/index.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)