### PR TITLE
Centralize electron-store instance into src/store.ts

### DIFF
--- a/src/device.ts
+++ b/src/device.ts
@@ -1,13 +1,9 @@
-import Store from 'electron-store'
-
 import { BrowserWindow, screen } from 'electron'
 import * as path from 'path'
 import ShortUniqueId from 'short-uuid'
-import { defaultSettings } from './defaults' // Your settings file
 import { showDevTools } from './utils' // Import utility to check if dev tools should be shown
 import { updateTrayMenu } from './tray'
-
-const store = new Store({ defaults: defaultSettings })
+import { store } from './store'
 
 export function createDeviceWindows() {
     const deviceIds = store.get('deviceIds') as string[] | undefined

--- a/src/hotkeys.ts
+++ b/src/hotkeys.ts
@@ -1,7 +1,5 @@
 import { globalShortcut } from 'electron'
-import Store from 'electron-store'
-
-const store = new Store()
+import { store } from './store'
 
 export function registerHotkey(
     hotkey: string,

--- a/src/ipcHandlers.ts
+++ b/src/ipcHandlers.ts
@@ -1,7 +1,5 @@
 import { ipcMain, BrowserWindow } from 'electron'
 import * as path from 'path'
-import Store from 'electron-store'
-import { defaultSettings } from './defaults'
 import { createSatellite, getNextProfileName } from './utils'
 import { updateTrayMenu } from './tray'
 
@@ -13,8 +11,7 @@ import {
     showDeviceLabels,
     resizeWindowForDevice,
 } from './device' // Import the device ID creation function
-
-const store = new Store({ defaults: defaultSettings })
+import { store } from './store'
 
 export function initializeIpcHandlers() {
     ipcMain.handle('getDeviceConfig', (_event, deviceId) => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,4 @@
+import Store from 'electron-store'
+import { defaultSettings } from './defaults'
+
+export const store = new Store({ defaults: defaultSettings })

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -1,6 +1,5 @@
 import { Tray, Menu, nativeImage, app } from 'electron'
 import * as path from 'path'
-import Store from 'electron-store'
 import createSettingsWindow from './settings' // Import the createSettingsWindow function
 import {
     loadProfile,
@@ -11,9 +10,9 @@ import {
 import { ProfilesStore } from './types' // Import the ProfilesStore type
 
 import { unregisterAllHotkeys } from './hotkeys' // Import hotkey management functions
+import { store } from './store'
 
 let tray: Tray | null = null
-const store = new Store()
 
 export default function createTray() {
     // Create the tray icon using nativeImage and resize it to the desired size

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,5 @@
 import { app, BrowserWindow, ipcMain } from 'electron'
-import Store from 'electron-store'
 import ShortUniqueId from 'short-uuid'
-import { defaultSettings } from './defaults' // Your settings file
 import path from 'path'
 import { createNewDevice, createDeviceWindows, showWindows } from './device' // Function to create a new device
 import { CompanionSatelliteClient } from './client' // Your new client class
@@ -9,8 +7,7 @@ import { updateTrayMenu } from './tray'
 import { ProfilesStore, Profile } from './types' // Import your types
 import { showNotification } from './notification'
 import { unregisterAllHotkeys, loadHotkeysFromStore } from './hotkeys' // Import hotkey management functions
-
-const store = new Store({ defaults: defaultSettings })
+import { store } from './store'
 
 export const showDevTools =
     process.env.NODE_ENV === 'development' || process.env.DEBUG_PROD === 'true'


### PR DESCRIPTION
## Summary
- Five main-process files (`src/utils.ts`, `src/device.ts`, `src/ipcHandlers.ts`, `src/tray.ts`, `src/hotkeys.ts`) each constructed their own `electron-store` instance pointing at the same underlying store file, with inconsistent defaults — `tray.ts` and `hotkeys.ts` omitted `defaultSettings` entirely.
- Added `src/store.ts` exporting a single shared `store` instance built with `defaultSettings`, and updated the five files to import it instead of constructing their own.
- No `store.get`/`store.set`/`store.delete` call sites were changed — only the import/construction lines.

**Note:** this touches the same files as several other in-flight bugfix PRs, so it may need rebasing depending on merge order.

## Test plan
- [x] `yarn build` (`tsc`, `strict: true`) compiles with no errors.
- [x] Verified no remaining references to `electron-store`, `new Store`, or unused `defaultSettings` imports in the five modified files.