### PR TITLE
Add per-device Reset to Defaults button in Settings

### DIFF
--- a/public/settings.js
+++ b/public/settings.js
@@ -221,6 +221,22 @@ window.addEventListener('DOMContentLoaded', () => {
             })
             actions.appendChild(deleteBtn)
 
+            const resetBtn = document.createElement('button')
+            resetBtn.textContent = 'Reset to Defaults'
+            resetBtn.addEventListener('click', async () => {
+                if (
+                    confirm(
+                        `Reset device ${device.deviceId} to default settings? This will not affect its hotkeys.`
+                    )
+                ) {
+                    await window.electronAPI.resetDeviceToDefaults(
+                        device.deviceId
+                    )
+                    loadDevices() // reload the whole list so displayed values reflect the reset
+                }
+            })
+            actions.appendChild(resetBtn)
+
             container.appendChild(actions)
             deviceList.appendChild(container)
         })

--- a/src/ipcHandlers.ts
+++ b/src/ipcHandlers.ts
@@ -17,6 +17,130 @@ import {
 } from './device' // Import the device ID creation function
 import { store } from './store'
 
+// Applies a partial (or full) device config: saves it to the store, updates
+// the live BrowserWindow, resizes it if needed, and notifies the renderer.
+// Shared by the `updateDeviceConfig` and `resetDeviceToDefaults` handlers.
+function applyDeviceConfig(deviceId: string, config: Record<string, any>) {
+    let needsDeviceUpdate = false
+
+    // Check if key properties have actually changed
+    for (const key of ['columnCount', 'rowCount', 'bitmapSize']) {
+        const oldValue = store.get(`device.${deviceId}.${key}`)
+        const newValue = config[key]
+
+        if (newValue !== undefined && newValue !== oldValue) {
+            needsDeviceUpdate = true
+            break
+        }
+    }
+
+    // Save all config values
+    Object.entries(config).forEach(([key, value]) => {
+        const fullKey = `device.${deviceId}.${key}`
+
+        if (value === undefined) {
+            store.delete(fullKey as any)
+        } else {
+            store.set(fullKey, value)
+        }
+    })
+
+    console.log(`Device ${deviceId} config updated:`, config)
+
+    // Update the BrowserWindow properties
+    const win = global.deviceWindows.get(deviceId)
+    if (win) {
+        if (config.alwaysOnTop !== undefined) {
+            win.setAlwaysOnTop(Boolean(config.alwaysOnTop))
+        }
+        if (config.movable !== undefined) {
+            win.setMovable(Boolean(config.movable))
+        }
+        if (config.disablePress !== undefined) {
+            win.webContents.send('disablePress', Boolean(config.disablePress))
+        }
+        if (config.autoHide !== undefined) {
+            win.webContents.send('autoHide', Boolean(config.autoHide))
+        }
+        if (config.hideEmptyKeys !== undefined) {
+            resizeWindowForDevice(deviceId)
+            win.webContents.send(
+                'hideEmptyKeys',
+                Boolean(config.hideEmptyKeys)
+            )
+        }
+
+        // Resize window if columnCount/rowCount/bitmapSize changed
+        if (needsDeviceUpdate) {
+            const columnCount = store.get(`device.${deviceId}.columnCount`, 8)
+            const rowCount = store.get(`device.${deviceId}.rowCount`, 4)
+            const bitmapSize = store.get(`device.${deviceId}.bitmapSize`, 72)
+
+            const { width, height } = calculateWindowSize(
+                columnCount,
+                rowCount,
+                bitmapSize
+            )
+
+            win.setSize(width, height)
+
+            // If the Satellite client is connected and key properties changed, update the device config
+            if (global.satelliteClient) {
+                global.satelliteClient.removeDevice(deviceId)
+                global.satelliteClient.addDevice(deviceId, 'ScreenDeck', {
+                    columnCount: store.get(
+                        `device.${deviceId}.columnCount`,
+                        8
+                    ),
+                    rowCount: store.get(`device.${deviceId}.rowCount`, 4),
+                    bitmapSize: store.get(
+                        `device.${deviceId}.bitmapSize`,
+                        72
+                    ),
+                    colours: true,
+                    text: true,
+                    brightness: true,
+                    pincodeMap: null,
+                })
+            }
+
+            win.webContents.send('rebuildGrid', {
+                columnCount,
+                rowCount,
+            })
+        }
+
+        // Update background color/opacity *live*
+        if (
+            config.backgroundColor !== undefined ||
+            config.backgroundOpacity !== undefined
+        ) {
+            const backgroundColor = store.get(
+                `device.${deviceId}.backgroundColor`,
+                '#000000'
+            )
+            const backgroundOpacity = store.get(
+                `device.${deviceId}.backgroundOpacity`,
+                0.5
+            )
+
+            console.log('Updating background color/opacity:', {
+                backgroundColor,
+                backgroundOpacity,
+            })
+
+            win.webContents.send('updateBackground', {
+                backgroundColor,
+                backgroundOpacity,
+            })
+        }
+
+        win.show()
+    }
+
+    updateTrayMenu()
+}
+
 export function initializeIpcHandlers() {
     ipcMain.handle('getDeviceConfig', (_event, deviceId) => {
         const columnCount = store.get(`device.${deviceId}.columnCount`, 8)
@@ -339,133 +463,27 @@ export function initializeIpcHandlers() {
     })
 
     ipcMain.handle('updateDeviceConfig', (_event, { deviceId, config }) => {
-        let needsDeviceUpdate = false
+        applyDeviceConfig(deviceId, config)
+    })
 
-        // Check if key properties have actually changed
-        for (const key of ['columnCount', 'rowCount', 'bitmapSize']) {
-            const oldValue = store.get(`device.${deviceId}.${key}`)
-            const newValue = config[key]
-
-            if (newValue !== undefined && newValue !== oldValue) {
-                needsDeviceUpdate = true
-                break
-            }
+    ipcMain.handle('resetDeviceToDefaults', (_event, deviceId) => {
+        // Mirrors the defaults set in device.ts's createNewDevice()
+        const defaultConfig = {
+            columnCount: 8,
+            rowCount: 4,
+            bitmapSize: 72,
+            alwaysOnTop: true,
+            movable: true,
+            disablePress: false,
+            backgroundColor: '#000000',
+            backgroundOpacity: 0.5,
         }
 
-        // Save all config values
-        Object.entries(config).forEach(([key, value]) => {
-            const fullKey = `device.${deviceId}.${key}`
+        applyDeviceConfig(deviceId, defaultConfig)
 
-            if (value === undefined) {
-                store.delete(fullKey as any)
-            } else {
-                store.set(fullKey, value)
-            }
-        })
+        console.log(`Device ${deviceId} reset to defaults.`)
 
-        console.log(`Device ${deviceId} config updated:`, config)
-
-        // Update the BrowserWindow properties
-        const win = global.deviceWindows.get(deviceId)
-        if (win) {
-            if (config.alwaysOnTop !== undefined) {
-                win.setAlwaysOnTop(Boolean(config.alwaysOnTop))
-            }
-            if (config.movable !== undefined) {
-                win.setMovable(Boolean(config.movable))
-            }
-            if (config.disablePress !== undefined) {
-                win.webContents.send(
-                    'disablePress',
-                    Boolean(config.disablePress)
-                )
-            }
-            if (config.autoHide !== undefined) {
-                win.webContents.send('autoHide', Boolean(config.autoHide))
-            }
-            if (config.hideEmptyKeys !== undefined) {
-                resizeWindowForDevice(deviceId)
-                win.webContents.send(
-                    'hideEmptyKeys',
-                    Boolean(config.hideEmptyKeys)
-                )
-            }
-
-            // Resize window if columnCount/rowCount/bitmapSize changed
-            if (needsDeviceUpdate) {
-                const columnCount = store.get(
-                    `device.${deviceId}.columnCount`,
-                    8
-                )
-                const rowCount = store.get(`device.${deviceId}.rowCount`, 4)
-                const bitmapSize = store.get(
-                    `device.${deviceId}.bitmapSize`,
-                    72
-                )
-
-                const { width, height } = calculateWindowSize(
-                    columnCount,
-                    rowCount,
-                    bitmapSize
-                )
-
-                win.setSize(width, height)
-
-                // If the Satellite client is connected and key properties changed, update the device config
-                if (global.satelliteClient) {
-                    global.satelliteClient.removeDevice(deviceId)
-                    global.satelliteClient.addDevice(deviceId, 'ScreenDeck', {
-                        columnCount: store.get(
-                            `device.${deviceId}.columnCount`,
-                            8
-                        ),
-                        rowCount: store.get(`device.${deviceId}.rowCount`, 4),
-                        bitmapSize: store.get(
-                            `device.${deviceId}.bitmapSize`,
-                            72
-                        ),
-                        colours: true,
-                        text: true,
-                        brightness: true,
-                        pincodeMap: null,
-                    })
-                }
-
-                win.webContents.send('rebuildGrid', {
-                    columnCount,
-                    rowCount,
-                })
-            }
-
-            // Update background color/opacity *live*
-            if (
-                config.backgroundColor !== undefined ||
-                config.backgroundOpacity !== undefined
-            ) {
-                const backgroundColor = store.get(
-                    `device.${deviceId}.backgroundColor`,
-                    '#000000'
-                )
-                const backgroundOpacity = store.get(
-                    `device.${deviceId}.backgroundOpacity`,
-                    0.5
-                )
-
-                console.log('Updating background color/opacity:', {
-                    backgroundColor,
-                    backgroundOpacity,
-                })
-
-                win.webContents.send('updateBackground', {
-                    backgroundColor,
-                    backgroundOpacity,
-                })
-            }
-
-            win.show()
-        }
-
-        updateTrayMenu()
+        return defaultConfig
     })
 
     ipcMain.handle('deleteDevice', (_event, deviceId) => {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -76,6 +76,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getDeviceConfig: (deviceId: string) =>
         ipcRenderer.invoke('getDeviceConfig', deviceId),
 
+    // Reset a device's settings back to createNewDevice()'s defaults
+    resetDeviceToDefaults: (deviceId: string) =>
+        ipcRenderer.invoke('resetDeviceToDefaults', deviceId),
+
     // Save settings (if you need it for settings page)
     saveSettings: (newSettings: any) =>
         ipcRenderer.invoke('saveSettings', newSettings),


### PR DESCRIPTION
## Summary
- Adds a `resetDeviceToDefaults` IPC handler that resets a device's columnCount, rowCount, bitmapSize, alwaysOnTop, movable, disablePress, backgroundColor, and backgroundOpacity back to the same defaults `createNewDevice()` uses in `src/device.ts`, without touching the device's `deviceId`, `keys`/hotkey config, or removing it from `deviceIds`.
- Factors the store-set + live window update + resize + Satellite re-add logic out of the existing `updateDeviceConfig` handler into a shared `applyDeviceConfig()` helper in `src/ipcHandlers.ts`, reused by both handlers instead of duplicating that logic.
- Exposes the new IPC call via a named `resetDeviceToDefaults` method in `src/preload.ts` (not via the generic `invoke` passthrough, since a separate in-flight PR may remove that passthrough).
- Adds a "Reset to Defaults" button next to the existing Save/Delete buttons for each device in the Settings window (`public/settings.js`), with a confirmation prompt, which reloads the device list afterward so displayed values reflect the reset.

This lets a device that's been resized/moved/misconfigured be restored without deleting and recreating it — deleting/recreating a device changes its `deviceId`, which would silently orphan any hotkeys assigned to it.

**Note:** This touches the same region of `public/settings.js` (the per-device `loadDevices()` action buttons) as the in-flight PR restoring the `hideEmptyKeys`/`autoHide` checkboxes, so it will likely need a rebase against whichever lands first.

## Test plan
- [ ] Resize and move a device's window, and change its background color/opacity and other settings via Settings.
- [ ] Assign one or more hotkeys to that device.
- [ ] Open Settings, click "Reset to Defaults" for that device, and confirm the dialog.
- [ ] Verify the device window snaps back to the 8x4 grid, 72px bitmap size, black background at 0.5 opacity, `alwaysOnTop`/`movable` true, `disablePress` false, and moves back near its default screen position on next window creation.
- [ ] Verify the device's hotkey assignments are unchanged after the reset.
- [ ] Verify the device keeps the same `deviceId` and is not removed/recreated.
- [ ] `yarn build` (tsc) passes with no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)