### PR TITLE
Harden preload API: remove generic invoke/send passthroughs

### DIFF
--- a/public/hotkeyPrompt.js
+++ b/public/hotkeyPrompt.js
@@ -22,7 +22,7 @@ window.addEventListener('DOMContentLoaded', () => {
     }
 
     // Get initial data
-    window.electronAPI.invoke('getHotkeyContext').then((data) => {
+    window.electronAPI.getHotkeyContext().then((data) => {
         deviceId = data.deviceId
         keyIndex = data.keyIndex
 
@@ -110,7 +110,7 @@ window.addEventListener('DOMContentLoaded', () => {
             btn.textContent = 'Clear'
             btn.addEventListener('click', () => {
                 window.electronAPI
-                    .invoke('clearHotkey', {
+                    .clearHotkey({
                         deviceId: h.deviceId,
                         keyIndex: h.keyIndex,
                         hotkey: h.hotkey,
@@ -157,7 +157,7 @@ window.addEventListener('DOMContentLoaded', () => {
         }
 
         window.electronAPI
-            .invoke('assignHotkey', {
+            .assignHotkey({
                 deviceId,
                 keyIndex,
                 hotkey: hotkeyStr,
@@ -174,11 +174,11 @@ window.addEventListener('DOMContentLoaded', () => {
     })
 
     document.getElementById('cancel').addEventListener('click', () => {
-        window.electronAPI.invoke('closeHotkeyPrompt')
+        window.electronAPI.closeHotkeyPrompt()
     })
 
     document.getElementById('closeButton').addEventListener('click', () => {
-        window.electronAPI.invoke('closeHotkeyPrompt')
+        window.electronAPI.closeHotkeyPrompt()
     })
 })
 

--- a/public/index.js
+++ b/public/index.js
@@ -38,7 +38,7 @@ window.addEventListener('DOMContentLoaded', () => {
     let globalHideEmptyKeys = false
 
     // Request config from main process
-    window.electronAPI.invoke('getDeviceConfig', deviceId).then((config) => {
+    window.electronAPI.getDeviceConfig(deviceId).then((config) => {
         const { autoHide, hideEmptyKeys, backgroundColor, backgroundOpacity } =
             config
 
@@ -83,11 +83,11 @@ window.addEventListener('DOMContentLoaded', () => {
 
             // Save current size before shrinking
             window.electronAPI
-                .invoke('getKeypadBounds', deviceId)
+                .getKeypadBounds(deviceId)
                 .then((bounds) => {
                     originalBounds = bounds
                     const bitmapSize = bounds.bitmapSize || 72
-                    window.electronAPI.invoke('resizeKeypadWindow', {
+                    window.electronAPI.resizeKeypadWindow({
                         deviceId,
                         width: bitmapSize + 50, // 50px padding
                         height: bitmapSize + 50, // 50px padding
@@ -115,7 +115,7 @@ window.addEventListener('DOMContentLoaded', () => {
             }
 
             // Restore original size
-            window.electronAPI.invoke('resizeKeypadWindow', {
+            window.electronAPI.resizeKeypadWindow({
                 deviceId,
                 width: originalBounds.width,
                 height: originalBounds.height,
@@ -332,7 +332,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
             if (action === 'encoder') {
                 window.electronAPI
-                    .invoke('updateKeyConfig', {
+                    .updateKeyConfig({
                         deviceId,
                         keyIndex,
                         config: { isEncoder: true },
@@ -340,7 +340,7 @@ window.addEventListener('DOMContentLoaded', () => {
                     .then(() => refreshKey(deviceId, keyIndex))
             } else if (action === 'button') {
                 window.electronAPI
-                    .invoke('updateKeyConfig', {
+                    .updateKeyConfig({
                         deviceId,
                         keyIndex,
                         config: { isEncoder: false },
@@ -399,12 +399,12 @@ window.addEventListener('DOMContentLoaded', () => {
             } else if (action === 'hotkey') {
                 let keyConfig = keyStates.get(deviceId)?.get(keyIndex)
                 let imageBase64 = keyConfig?.imageBase64 || null
-                window.electronAPI.invoke('setHotkeyContext', {
+                window.electronAPI.setHotkeyContext({
                     deviceId,
                     keyIndex,
                     imageBase64,
                 })
-                window.electronAPI.invoke('openHotkeyPrompt')
+                window.electronAPI.openHotkeyPrompt()
             }
 
             closeContextMenu()
@@ -442,7 +442,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
     function refreshKey(deviceId, keyIndex) {
         window.electronAPI
-            .invoke('getKeyConfig', { deviceId, keyIndex })
+            .getKeyConfig({ deviceId, keyIndex })
             .then((keyConfig) => {
                 const keyElement = keyElements[keyIndex]
                 if (!keyElement) return
@@ -588,7 +588,7 @@ window.addEventListener('DOMContentLoaded', () => {
     }
 
     function sendKeyPressXY(x, y, action) {
-        window.electronAPI.send('keyPress', {
+        window.electronAPI.keyPress({
             deviceId,
             x,
             y,
@@ -634,7 +634,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
         setTimeout(() => {
             window.electronAPI
-                .invoke('getDeviceConfig', deviceId)
+                .getDeviceConfig(deviceId)
                 .then((config) => {
                     console.log('got config:', config)
                     const { backgroundColor, backgroundOpacity } = config
@@ -692,7 +692,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
     // Close button
     document.getElementById('closeButton').addEventListener('click', () => {
-        window.electronAPI.invoke('closeKeypad', deviceId) // Send deviceId so main process knows which to close
+        window.electronAPI.closeKeypad(deviceId) // Send deviceId so main process knows which to close
     })
 
     function processKey(keyObj) {

--- a/public/index.js
+++ b/public/index.js
@@ -348,7 +348,7 @@ window.addEventListener('DOMContentLoaded', () => {
                     .then(() => refreshKey(deviceId, keyIndex))
             } else if (action === 'button-sticky') {
                 window.electronAPI
-                    .invoke('updateKeyConfig', {
+                    .updateKeyConfig({
                         deviceId,
                         keyIndex,
                         config: { isEncoder: false, isSticky: true },

--- a/public/index.js
+++ b/public/index.js
@@ -356,7 +356,7 @@ window.addEventListener('DOMContentLoaded', () => {
                     .then(() => refreshKey(deviceId, keyIndex))
             } else if (action === 'set-step-size') {
                 window.electronAPI
-                    .invoke('getKeyConfig', { deviceId, keyIndex })
+                    .getKeyConfig({ deviceId, keyIndex })
                     .then((current) => {
                         const input = prompt(
                             'Enter step size (degrees per notch):',
@@ -369,7 +369,7 @@ window.addEventListener('DOMContentLoaded', () => {
                             return
                         }
                         window.electronAPI
-                            .invoke('updateKeyConfig', {
+                            .updateKeyConfig({
                                 deviceId,
                                 keyIndex,
                                 config: {
@@ -382,10 +382,10 @@ window.addEventListener('DOMContentLoaded', () => {
                     })
             } else if (action === 'clear-sticky') {
                 window.electronAPI
-                    .invoke('getKeyConfig', { deviceId, keyIndex })
+                    .getKeyConfig({ deviceId, keyIndex })
                     .then((current) => {
                         window.electronAPI
-                            .invoke('updateKeyConfig', {
+                            .updateKeyConfig({
                                 deviceId,
                                 keyIndex,
                                 config: {

--- a/public/settings.js
+++ b/public/settings.js
@@ -14,7 +14,7 @@ window.addEventListener('DOMContentLoaded', () => {
                 10
             )
 
-            await window.electronAPI.invoke('saveSettings', {
+            await window.electronAPI.saveSettings({
                 companionIP: ip,
                 companionPort: port,
             })
@@ -26,16 +26,16 @@ window.addEventListener('DOMContentLoaded', () => {
             // Optionally clear the message after a few seconds
             setTimeout(() => {
                 status.textContent = ''
-                window.electronAPI.invoke('closeSettingsWindow')
+                window.electronAPI.closeSettingsWindow()
             }, 1000)
         })
 
     document.getElementById('closeButton').addEventListener('click', () => {
-        window.electronAPI.invoke('closeSettingsWindow')
+        window.electronAPI.closeSettingsWindow()
     })
 
     async function loadCompanionSettings() {
-        const settings = await window.electronAPI.invoke('getSettings')
+        const settings = await window.electronAPI.getSettings()
 
         document.getElementById('companionIP').value =
             settings.companionIP || '127.0.0.1'
@@ -44,7 +44,7 @@ window.addEventListener('DOMContentLoaded', () => {
     }
 
     async function loadDevices() {
-        const devices = await window.electronAPI.invoke('getAllDevices')
+        const devices = await window.electronAPI.getAllDevices()
         deviceList.innerHTML = ''
 
         devices.forEach((device) => {
@@ -110,14 +110,14 @@ window.addEventListener('DOMContentLoaded', () => {
             backgroundOpacityLabel.appendChild(backgroundOpacityInput)
 
             /*backgroundColorInput.addEventListener('input', async () => {
-                await window.electronAPI.invoke('updateDeviceConfig', {
+                await window.electronAPI.updateDeviceConfig({
                     deviceId: device.deviceId,
                     config: { backgroundColor: backgroundColorInput.value },
                 })
             })*/
 
             backgroundOpacityInput.addEventListener('input', async () => {
-                await window.electronAPI.invoke('updateDeviceConfig', {
+                await window.electronAPI.updateDeviceConfig({
                     deviceId: device.deviceId,
                     config: {
                         backgroundOpacity: parseFloat(
@@ -178,7 +178,7 @@ window.addEventListener('DOMContentLoaded', () => {
                     backgroundColor: backgroundColorInput.value,
                     backgroundOpacity: parseFloat(backgroundOpacityInput.value),
                 }
-                await window.electronAPI.invoke('updateDeviceConfig', {
+                await window.electronAPI.updateDeviceConfig({
                     deviceId: device.deviceId,
                     config,
                 })
@@ -212,10 +212,7 @@ window.addEventListener('DOMContentLoaded', () => {
             deleteBtn.style.color = 'white'
             deleteBtn.addEventListener('click', async () => {
                 if (confirm(`Delete device ${device.deviceId}?`)) {
-                    await window.electronAPI.invoke(
-                        'deleteDevice',
-                        device.deviceId
-                    )
+                    await window.electronAPI.deleteDevice(device.deviceId)
                     loadDevices()
                 }
             })
@@ -271,7 +268,7 @@ window.addEventListener('DOMContentLoaded', () => {
     }
 
     addDeviceButton.addEventListener('click', async () => {
-        await window.electronAPI.invoke('createNewDevice')
+        await window.electronAPI.createNewDevice()
         loadDevices()
     })
 })

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,11 +1,13 @@
 import { contextBridge, ipcRenderer } from 'electron'
 
-// Expose APIs to the renderer process through contextBridge
+// Expose APIs to the renderer process through contextBridge.
+//
+// Every IPC channel gets its own named, single-purpose method here instead of
+// a generic invoke/send passthrough. A generic passthrough would let any
+// renderer script call *any* registered ipcMain handler with arbitrary
+// arguments, which defeats the point of contextIsolation/nodeIntegration as a
+// security boundary.
 contextBridge.exposeInMainWorld('electronAPI', {
-    // Wrapper for invoking IPC methods
-    invoke: (channel: string, data?: any) => ipcRenderer.invoke(channel, data),
-    send: (channel: string, data?: any) => ipcRenderer.send(channel, data),
-
     getNextProfileName: () => ipcRenderer.invoke('getNextProfileName'),
 
     sendProfileName: (name: string) =>
@@ -80,7 +82,92 @@ contextBridge.exposeInMainWorld('electronAPI', {
     resetDeviceToDefaults: (deviceId: string) =>
         ipcRenderer.invoke('resetDeviceToDefaults', deviceId),
 
+    // Get the current window bounds for a device's keypad window
+    getKeypadBounds: (deviceId: string) =>
+        ipcRenderer.invoke('getKeypadBounds', deviceId),
+
+    // Resize a device's keypad window
+    resizeKeypadWindow: (data: {
+        deviceId: string
+        width: number
+        height: number
+    }) => ipcRenderer.invoke('resizeKeypadWindow', data),
+
+    // Close (hide) a device's keypad window
+    closeKeypad: (deviceId: string) =>
+        ipcRenderer.invoke('closeKeypad', deviceId),
+
+    // Send a key press/release/rotate event (fire-and-forget)
+    keyPress: (data: {
+        deviceId: string
+        x: number
+        y: number
+        action: string
+    }) => ipcRenderer.send('keyPress', data),
+
+    // Get per-key config (isEncoder, stepSize)
+    getKeyConfig: (data: { deviceId: string; keyIndex: number }) =>
+        ipcRenderer.invoke('getKeyConfig', data),
+
+    // Update per-key config (isEncoder, stepSize)
+    updateKeyConfig: (data: {
+        deviceId: string
+        keyIndex: number
+        config: any
+    }) => ipcRenderer.invoke('updateKeyConfig', data),
+
+    // Toggle a key between encoder/button mode
+    toggleEncoder: (data: { deviceId: string; keyIndex: number }) =>
+        ipcRenderer.invoke('toggleEncoder', data),
+
+    // Broadcast a brightness change to all device windows
+    setBrightness: (brightness: number) =>
+        ipcRenderer.invoke('setBrightness', brightness),
+
+    //HOTKEYS
+    setHotkeyContext: (data: {
+        deviceId: string
+        keyIndex: number
+        imageBase64?: string | null
+    }) => ipcRenderer.invoke('setHotkeyContext', data),
+
+    getHotkeyContext: () => ipcRenderer.invoke('getHotkeyContext'),
+
+    openHotkeyPrompt: () => ipcRenderer.invoke('openHotkeyPrompt'),
+
+    closeHotkeyPrompt: () => ipcRenderer.invoke('closeHotkeyPrompt'),
+
+    assignHotkey: (data: {
+        deviceId: string
+        keyIndex: number
+        hotkey: string
+    }) => ipcRenderer.invoke('assignHotkey', data),
+
+    clearHotkey: (data: {
+        deviceId: string
+        keyIndex: number
+        hotkey: string
+    }) => ipcRenderer.invoke('clearHotkey', data),
+
+    showDeviceLabels: (show: boolean) =>
+        ipcRenderer.invoke('showDeviceLabels', show),
+
+    //SETTINGS
+    createNewDevice: () => ipcRenderer.invoke('createNewDevice'),
+
+    getAllDevices: () => ipcRenderer.invoke('getAllDevices'),
+
+    updateDeviceConfig: (data: { deviceId: string; config: any }) =>
+        ipcRenderer.invoke('updateDeviceConfig', data),
+
+    deleteDevice: (deviceId: string) =>
+        ipcRenderer.invoke('deleteDevice', deviceId),
+
+    getSettings: () => ipcRenderer.invoke('getSettings'),
+
     // Save settings (if you need it for settings page)
     saveSettings: (newSettings: any) =>
         ipcRenderer.invoke('saveSettings', newSettings),
+
+    closeSettingsWindow: () => ipcRenderer.invoke('closeSettingsWindow'),
 })


### PR DESCRIPTION
## Summary

- `src/preload.ts` exposed generic `invoke(channel, data)` / `send(channel, data)` wrappers on `window.electronAPI`. These let any renderer script call *any* registered `ipcMain` handler with arbitrary arguments — which defeats much of the point of `contextIsolation: true` / `nodeIntegration: false` as a security boundary. If this app ever loaded untrusted/remote content, or a dependency introduced an XSS, it would get full access to every privileged main-process handler instead of just the specific operations a given renderer legitimately needs.
- Replaced both generic passthroughs with one named method per IPC channel (mirroring the naming convention already used for `getNextProfileName`, `sendProfileName`, `getDeviceConfig`, `saveSettings`, etc.). Also added named wrappers for a couple of `ipcMain` channels that exist but weren't yet called from any renderer (`toggleEncoder`, `setBrightness`, `showDeviceLabels`) for completeness — no new behavior was invented, they just call the existing handler.
- Updated every call site in `public/index.js`, `public/settings.js`, and `public/hotkeyPrompt.js` to use the new named methods instead of raw channel-name strings passed to `invoke`/`send`. This also fixes the prior inconsistency where `getDeviceConfig` and `saveSettings` were exposed as named methods but were still being called generically in other places.
- `public/profilePrompt.html` required no changes — it already used the named `getNextProfileName`/`sendProfileName` methods.
- This is a mechanical rename with no intended behavior change: arguments and `.then()`/async handling are preserved exactly at every call site.

## Notes for reviewers

This is a **broad, mechanical change that touches every renderer IPC call site** in the app. Since nearly all other in-flight PRs likely add or change `window.electronAPI` calls, this PR should probably be **merged/rebased last** relative to other open PRs to minimize conflicts.

## Test plan

Manual smoke test needed for every renderer window/feature, since this touches all IPC call sites:

- [ ] **Device/keypad windows** (`public/index.js`): app loads device config on open, keypad grid renders, key press/release sends work (`keyPress`), encoder rotation works, right-click context menu → "Set to Encoder/Button Mode" persists, "Assign Hotkey..." opens the hotkey prompt with correct context, auto-hide-on-mouse-leave resizes/restores the window (`getKeypadBounds`/`resizeKeypadWindow`), identify flash reloads background color, close button closes the keypad window (`closeKeypad`)
- [ ] **Settings window** (`public/settings.js`): opens with current Companion IP/port, save Companion settings persists and reconnects, device list loads (`getAllDevices`), per-device Save updates config live, per-device Delete removes the device and window, "Add Device" creates a new device window, close button closes settings window
- [ ] **Hotkey prompt** (`public/hotkeyPrompt.js`): opens with correct device/key context and bitmap preview, existing hotkey list renders with working "Clear" buttons, assigning a new hotkey (with modifier + primary key) saves and closes the prompt, cancel/close buttons close the prompt without saving
- [ ] **Profile prompt** (`public/profilePrompt.html`): unaffected by this change, but worth confirming "Save Profile" flow (suggested name loads, OK/Cancel send the expected result) still works end-to-end since it's adjacent code

## Build

`yarn build` (`tsc`) passes with no errors.