### PR TITLE
Fix #9: keep macOS device overlay visible across Spaces and full-screen apps

### DIFF
--- a/src/device.ts
+++ b/src/device.ts
@@ -69,6 +69,11 @@ export function createDeviceWindow(deviceId: string) {
         },
     })
 
+    // On macOS, keep the overlay visible across all Spaces/desktops and over full-screen apps
+    if (process.platform === 'darwin') {
+        win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })
+    }
+
     win.loadFile(path.join(__dirname, '../public/index.html'), {
         query: { deviceId },
     })


### PR DESCRIPTION
## Summary
- Fixes #9: on macOS, the ScreenDeck device window overlay would disappear when the user switched to a different full-screen app or a different Space/virtual desktop, since by default a window only stays on the desktop it was created on.
- Calls `win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })` on macOS right after each device `BrowserWindow` is constructed in `createDeviceWindow` (`src/device.ts`), so the overlay follows the user across Spaces and stays visible over full-screen apps.
- Scoped to `process.platform === 'darwin'` only; no behavior change on Windows/Linux. Only `src/device.ts` was touched.

The maintainer already linked a working reference implementation of this exact behavior in their other project (https://github.com/josephadams/beacon) in the issue thread for #9.

## Test plan
- [x] `yarn build` (`tsc`) compiles with no errors.
- [x] Sanity-launched the built app (`./node_modules/.bin/electron .`), confirmed device window(s) created and connected to Companion with no startup errors, then killed the process (verified no lingering Electron/ScreenDeck processes afterward).
- [ ] Manual verification on macOS of the actual fix (switching Spaces / toggling a full-screen app and confirming the overlay persists) — this is inherently a manual, interactive macOS Spaces/full-screen behavior that cannot be meaningfully verified by an automated agent; please confirm on a real macOS session before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)