### PR TITLE
Add drag handle to make moving windows easier

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,7 @@
                 class="connection-status"
                 title="Companion connection status"
             ></div>
+            <div id="dragHandle" class="drag-handle" title="Drag to move"></div>
 
             <!-- The main content area -->
             <div id="keypad" class="keypad">

--- a/public/styles.css
+++ b/public/styles.css
@@ -323,6 +323,37 @@ input[type='color'] {
     background: #f44336;
 }
 
+/* Always-visible grip handle for repositioning the window when the key
+   grid is fully packed and leaves no empty background area to drag from. */
+.drag-handle {
+    -webkit-app-region: drag;
+    pointer-events: auto;
+    position: absolute;
+    top: 4px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 28px;
+    height: 6px;
+    border-radius: 3px;
+    background-color: rgba(0, 0, 0, 0.5);
+    background-image: repeating-linear-gradient(
+        to right,
+        rgba(255, 255, 255, 0.6) 0px,
+        rgba(255, 255, 255, 0.6) 3px,
+        transparent 3px,
+        transparent 6px
+    );
+    z-index: 100;
+    cursor: move;
+    opacity: 0.5;
+    transition: opacity 0.2s ease;
+}
+
+.window-container:hover .drag-handle,
+.drag-handle:hover {
+    opacity: 0.9;
+}
+
 .keypad.identify-highlight {
     outline: 3px solid yellow;
     box-shadow: 0 0 30px 10px rgba(255, 255, 0, 0.8);


### PR DESCRIPTION
## Summary
- Closes #37. When the device key grid is fully packed with buttons, there's no empty background left to grab for repositioning the window (dragging currently relies on `-webkit-app-region: drag` on empty background area).
- Adds a small, always-visible grip handle (`#dragHandle` / `.drag-handle`) at the top-center of each device window, styled to match the existing dark/translucent aesthetic of `.close-button` / `.lock-indicator` / `.connection-status`.
- The handle explicitly sets `-webkit-app-region: drag` and does not set `pointer-events: none`, so it's a real grabbable affordance distinct from the non-interactive `#dragRegion`-style background drag areas.
- No JavaScript changes were needed — this is a pure CSS/HTML addition since window dragging is handled natively via the CSS `-webkit-app-region` property.

## Note for reviewer
The actual drag-grab UX (is the handle discoverable enough, is top-center the right placement, is the size/opacity right) is a subjective call. Would appreciate the original reporter's feedback on issue #37 on whether this treatment actually solves their problem before merging.

## Test plan
- [x] `node -c public/index.js` (no JS changes, sanity-checked anyway)
- [x] `yarn build` succeeds
- [x] Launched the built app in the background; connected to Companion, drew keys, resized windows with no errors in the log
- [x] Confirmed no lingering `screendeck`/Electron processes after killing the test run
- [ ] Manual visual/UX check of the handle in a real window (not done in this sandboxed environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)