### PR TITLE
Low-confidence attempt: Windows shortcut icon-cache workaround (#48)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,8 @@ yarn-error.log*
 
 # Compiled output
 dist/
-build/
+build/*
+!build/installer.nsh
 
 # Runtime data
 pids

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,27 @@
+; Custom NSIS include for electron-builder.
+;
+; Workaround for GitHub issue #48: after a fresh install on Windows, the
+; Start Menu / Desktop shortcut sometimes shows a generic/blank icon instead
+; of the app icon until the user opens the folder a few times. This is a
+; well-known class of Windows Explorer icon-cache staleness that can occur
+; right after an NSIS installer creates a new executable and shortcuts
+; pointing at it.
+;
+; "customInstall" is a documented electron-builder/NSIS hook: app-builder-lib's
+; installSection.nsh contains
+;   !ifmacrodef customInstall
+;     !insertmacro customInstall
+;   !endif
+; which runs immediately after the Start Menu and Desktop shortcuts have
+; been created (see addStartMenuLink / addDesktopLink earlier in the same
+; file), so this fires at the right point in the install sequence.
+;
+; SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, NULL, NULL) asks Explorer
+; to flush its icon/association cache and re-read shell icons. This is the
+; standard, commonly cited technique for this exact symptom, but it is a
+; best-effort mitigation for Explorer cache flakiness, not a guaranteed fix,
+; and it has NOT been verified against a real installation of this app on
+; Windows.
+!macro customInstall
+  System::Call 'shell32::SHChangeNotify(i 0x8000000, i 0, i 0, i 0)'
+!macroend

--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
             "target": "nsis",
             "icon": "assets/tray-icon.ico"
         },
+        "nsis": {
+            "include": "build/installer.nsh"
+        },
         "linux": {
             "target": [
                 {


### PR DESCRIPTION
## LOW CONFIDENCE / UNVERIFIED — please read before trusting this

This is a **best-effort attempt at a well-known workaround**, not a confirmed fix. I cannot verify it because I do not have access to a real Windows machine to install the app and observe Explorer's shortcut icon behavior. **This needs to be tested on an actual Windows install before it can be considered to resolve #48.**

## Context

Closes/relates to #48: after installing on Windows, the Start Menu / Desktop shortcut sometimes shows the wrong (generic/blank) icon until the user reopens the folder a few times.

The icon file itself (`assets/tray-icon.ico`) has already been confirmed to be a well-formed multi-resolution `.ico` (includes a 256x256 PNG-compressed entry), so the file is not the problem. This class of symptom — a freshly-installed NSIS app's shortcut not immediately showing the right icon — is a commonly reported category of **Windows Explorer icon-cache staleness**, not necessarily anything wrong with this app's build.

## What this PR does

- Adds `build/installer.nsh` with a `customInstall` NSIS macro that calls:
  ```
  System::Call 'shell32::SHChangeNotify(i 0x8000000, i 0, i 0, i 0)'
  ```
  i.e. `SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, NULL, NULL)`, which asks Explorer to flush its icon/shell association cache. This is the standard technique cited for this exact symptom with NSIS-based installers.
- Wires it in via `build.nsis.include` in `package.json`.
- Adjusts `.gitignore` so `build/installer.nsh` isn't swallowed by the existing (pre-existing, unrelated) `build/` ignore rule; `build/*` + a negation for the one file preserves the original intent for any actual build output.

## Verification performed

- Confirmed `customInstall` is a **real, documented electron-builder/NSIS hook** — not invented. In this repo's `node_modules/app-builder-lib/templates/nsis/installSection.nsh`:
  ```
  !ifmacrodef customInstall
    !insertmacro customInstall
  !endif
  ```
  runs immediately after `addStartMenuLink` / `addDesktopLink` (i.e., after both shortcuts are created), so the timing is correct for a post-install cache-refresh call.
- `node -e "require('./package.json')"` confirms the JSON is still valid.
- `yarn build` (plain `tsc`) succeeds — this change does not touch the TypeScript build.

## Verification NOT performed (cannot be done here)

- **Have not run the actual NSIS/Windows installer.** I have no Windows machine available in this environment, so I cannot confirm whether this actually changes the shortcut-icon behavior described in #48. `SHChangeNotify` is a broadly-cited workaround for this class of Explorer cache issue, but Explorer icon-cache behavior can be inconsistent across Windows versions/configurations, and it's possible this has no effect, or that the real fix lies elsewhere (e.g., icon cache database corruption on the specific test machine, antivirus interference, etc.).

**Please test a real Windows install (ideally a clean VM) before treating this as resolved.** If the shortcut icon issue persists after this change, this PR should not be treated as a fix and further investigation is needed.