### PR TITLE
Notify user when Companion version is unsupported (partial fix for #54)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -27,7 +27,7 @@ const PING_INTERVAL = 100
 const RECONNECT_DELAY = 1000
 const RECONNECT_DELAY_UNSUPPORTED = 30000
 
-const MINIMUM_PROTOCOL_VERSION = '1.7.0' // Companion 3.4
+export const MINIMUM_PROTOCOL_VERSION = '1.7.0' // Companion 3.4
 
 function parseLineParameters(line: string): Record<string, string | boolean> {
     const makeSafe = (index: number): number => {
@@ -107,6 +107,7 @@ export type CompanionSatelliteClientEvents = {
     variableValue: [{ deviceId: string; name: string; value: string }]
     lockedState: [{ deviceId: string; locked: boolean; characterCount: number }]
     deviceErrored: [{ deviceId: string; message: string }]
+    unsupportedVersion: [{ companionVersion: string | null; apiVersion: string | null }]
 }
 
 export class CompanionSatelliteClient
@@ -446,6 +447,10 @@ export class CompanionSatelliteClient
             console.log(
                 `Connected to unsupported Companion version. Companion ${this._companionVersion}, API ${this._companionApiVersion}`
             )
+            this.emit('unsupportedVersion', {
+                companionVersion: this._companionVersion,
+                apiVersion: this._companionApiVersion,
+            })
             this.socket?.end()
             return
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import ShortUniqueId from 'short-uuid'
 import path from 'path'
 import { createNewDevice, createDeviceWindows, showWindows } from './device' // Function to create a new device
 import { resizeWindowForDevice } from './device'
-import { CompanionSatelliteClient } from './client' // Your new client class
+import { CompanionSatelliteClient, MINIMUM_PROTOCOL_VERSION } from './client' // Your new client class
 import { updateTrayMenu } from './tray'
 import { ProfilesStore, Profile } from './types' // Import your types
 import { showNotification } from './notification'
@@ -27,6 +27,11 @@ export function initializeDeviceIds() {
 // Companion Satellite Client
 // ===========================
 
+// Tracks whether we've already shown a notification for the current
+// "unsupported Companion version" streak, so we don't spam the user with a
+// fresh OS notification on every reconnect attempt (every 30s, forever).
+let unsupportedVersionNotified = false
+
 export function createSatellite() {
     // Create the CompanionSatelliteClient
     if (global.satelliteClient?.connected) {
@@ -42,8 +47,26 @@ export function createSatellite() {
         console.error(`[Satellite Error] ${err}`)
     )
 
+    global.satelliteClient.on('unsupportedVersion', ({ companionVersion, apiVersion }) => {
+        console.error(
+            `[Satellite] Unsupported Companion version. Companion ${companionVersion}, API ${apiVersion}`
+        )
+
+        if (!unsupportedVersionNotified) {
+            unsupportedVersionNotified = true
+            showNotification(
+                'Companion Version Not Supported',
+                `Detected Companion ${companionVersion ?? 'unknown'} (API ${apiVersion ?? 'unknown'}), which is too old for ScreenDeck. ` +
+                    `Please update Companion to a version supporting API ${MINIMUM_PROTOCOL_VERSION} or newer.`
+            )
+        }
+    })
+
     global.satelliteClient.on('connected', () => {
         console.log('[Satellite] Connected Event Received')
+        // A successful connection means we're no longer in an "unsupported
+        // version" streak, so reset the notification guard for next time.
+        unsupportedVersionNotified = false
         // Register devices
         setTimeout(() => {
             const deviceIds = store.get('deviceIds') as string[] | []


### PR DESCRIPTION
## Summary

Partial, diagnostic-only improvement toward #54 ("No Connection to Companion").

The root cause of the connection failures reported in #54 (Companion 4.2.5, 4.3.4) is **not confirmed** — the issue thread doesn't have enough logs to pin down what these users are actually hitting. This PR does not claim to fix #54.

What it does fix: a concrete, existing gap found while investigating. `CompanionSatelliteClient.handleBegin()` already detects when a connected Companion instance reports an API version below `MINIMUM_PROTOCOL_VERSION` and closes the socket — but the only feedback was a `console.log()`, which end users of a packaged Electron app never see. The client then silently retries every 30 seconds, forever, with zero visible indication anything is wrong.

Changes:
- `src/client.ts`: added a new `unsupportedVersion` event (`{ companionVersion, apiVersion }`) emitted from `handleBegin()` right before the existing socket close/return, alongside the existing `console.log`. Also exported `MINIMUM_PROTOCOL_VERSION` so the notification can reference it.
- `src/utils.ts`: `createSatellite()` now listens for `unsupportedVersion` and shows one OS notification via the existing `showNotification()` helper, naming the detected Companion/API version and the minimum required API version. A simple module-level boolean guards against renotifying on every 30s retry — it resets when a `connected` event fires, so a new failure streak still gets its own notification.

This may well be the actual cause behind some of the reports in #54 (e.g. Companion 4.2.5/4.3.4 could predate the minimum supported protocol version), but since it can't be confirmed from the issue thread alone, this PR is framed as making that one specific failure mode diagnosable rather than as a guaranteed fix for the issue.

## Test plan
- [x] `yarn build` (`tsc`) compiles with no errors
- [x] Traced the code path: `handleBegin()` emits `unsupportedVersion` before `socket.end()`/`return`; `createSatellite()`'s listener calls `showNotification` with the detected versions; the notification guard resets on `connected`
- [x] Launched the built app locally against a real (supported) Companion instance — connected successfully, no startup errors or crashes; verified no lingering Electron processes afterward

Refs #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)