### PR TITLE
Fix: ScreenDeck windows don't show on startup

### DIFF
--- a/public/settings.html
+++ b/public/settings.html
@@ -78,6 +78,13 @@
                 style="width: 60px"
             />
 
+            <br />
+            <label for="showOnStartup">
+                <input type="checkbox" id="showOnStartup" />
+                Show ScreenDeck on Startup
+            </label>
+            <br />
+
             <button id="saveCompanion" style="width: 80x">Save</button>
             <span
                 id="saveStatus"

--- a/public/settings.js
+++ b/public/settings.js
@@ -14,9 +14,13 @@ window.addEventListener('DOMContentLoaded', () => {
                 10
             )
 
+            const showOnStartup =
+                document.getElementById('showOnStartup').checked
+
             await window.electronAPI.saveSettings({
                 companionIP: ip,
                 companionPort: port,
+                showOnStartup: showOnStartup,
             })
 
             // Show status message
@@ -41,6 +45,8 @@ window.addEventListener('DOMContentLoaded', () => {
             settings.companionIP || '127.0.0.1'
         document.getElementById('companionPort').value =
             settings.companionPort || 16622
+        document.getElementById('showOnStartup').checked =
+            settings.showOnStartup !== false
     }
 
     async function loadDevices() {

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -3,6 +3,7 @@
 export const defaultSettings = {
     companionIP: '127.0.0.1',
     companionPort: 16622,
+    showOnStartup: true,
     deviceIds: [],
 }
 

--- a/src/device.ts
+++ b/src/device.ts
@@ -129,11 +129,16 @@ export function createDeviceWindow(deviceId: string) {
 }
 
 // Show all device windows
-export function showWindows() {
+// When `ignoreHiddenState` is true, every device window is shown regardless of
+// its persisted per-device `hidden` flag. This is used on initial app startup so
+// that a device the user previously closed (which sets `hidden = true`) doesn't
+// stay hidden forever. During normal operation (tray Hide/Show, in-window close
+// button, etc.) callers should omit the argument to keep respecting `hidden`.
+export function showWindows(ignoreHiddenState = false) {
     global.deviceWindows.forEach((win, deviceId) => {
         console.log(`Showing window for deviceId: ${deviceId}`)
         const hidden = store.get(`device.${deviceId}.hidden`, false)
-        if (!hidden) {
+        if (ignoreHiddenState || !hidden) {
             win.show()
             win.focus()
             win.webContents.send('windowShown', { deviceId })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,7 +61,11 @@ export function createSatellite() {
             }
 
             updateTrayMenu()
-            showWindows()
+
+            // On initial startup, ignore any persisted per-device `hidden` flags so
+            // decks the user previously closed don't stay hidden forever (issues #53, #49).
+            const showOnStartup = store.get('showOnStartup', true) as boolean
+            showWindows(showOnStartup)
 
             global.deviceWindows.forEach((win) => {
                 win.webContents.send('satelliteStatus', 'connected')


### PR DESCRIPTION
## Root cause

Fixes #53 and #49 (duplicates of the same request: "Show ScreenDeck on startup" / "Auto open deck display on startup").

`showWindows()` in `src/device.ts` is called once after the satellite client connects (from `createSatellite()` in `src/utils.ts`), and it always honored the persisted per-device `hidden` flag:

```ts
export function showWindows() {
    global.deviceWindows.forEach((win, deviceId) => {
        const hidden = store.get(`device.${deviceId}.hidden`, false)
        if (!hidden) {
            win.show()
            ...
        } else {
            win.hide()
        }
    })
}
```

If a user ever closed a deck window with its in-window close button (which sets `device.<id>.hidden = true` via the `closeKeypad` IPC handler), that device stayed hidden on every subsequent launch forever — even when launched via a Windows startup-folder shortcut. The tray icon would appear, but no deck windows would show until the user manually opened the tray menu and clicked "Show All Screen Decks". This matches every report in the issue threads exactly.

## Fix

- Added a new **global** setting `showOnStartup` (default `true`) in `src/defaults.ts`, alongside `companionIP`/`companionPort`.
- `showWindows()` in `src/device.ts` now accepts `showWindows(ignoreHiddenState = false)`. When `true`, it shows every device window unconditionally, ignoring the persisted `hidden` flag.
- The single call site in `createSatellite()` (`src/utils.ts`, on the `'connected'` event) now reads `showOnStartup` from the store and passes it through: `showWindows(showOnStartup)`. This is the only place `showWindows()` is called anywhere in the codebase, so this is the only startup-time behavior affected.
- All other in-session behavior (tray Hide/Show, the in-window close button, Settings per-device `hidden` toggling) is unchanged, since `hidden` is still respected whenever `ignoreHiddenState` is `false`.
- Added a "Show ScreenDeck on Startup" checkbox to the global Companion settings section in `public/settings.html`/`public/settings.js`, wired through the existing `getSettings()`/`saveSettings()` flow.

## Test plan

- [x] `yarn build` (`tsc`) compiles cleanly
- [x] `node -c public/settings.js` confirms valid syntax
- [x] Launched the built app against a real, populated store (`~/Library/Application Support/screendeck/config.json`) that had a device with `"hidden": true` persisted from a prior session; confirmed in logs that the device window was shown anyway on startup (`Showing window for deviceId: ...` / `All device windows shown`), with no errors
- [x] Confirmed `showOnStartup: true` was written to the store via electron-store's `defaults` mechanism
- [x] Verified no lingering Electron/ScreenDeck processes after killing the test run