### PR TITLE
Add touch support and encoder press-vs-drag detection

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -494,58 +494,9 @@ window.addEventListener('DOMContentLoaded', () => {
     function bindKeyEvents(key, i, keyConfig) {
         const isEncoder = keyConfig.isEncoder
         const stepSize = keyConfig.stepSize || 10
-
-        key.addEventListener('mousedown', (e) => {
-            if (e.button === 2) {
-                return
-            }
-
-            if (isEncoder) {
-                e.preventDefault()
-
-                let lastX = e.clientX
-
-                const onMove = (moveEvent) => {
-                    const deltaX = moveEvent.clientX - lastX
-                    lastX = moveEvent.clientX
-                    handleDirection(deltaX)
-                }
-
-                const onEnter = () => {
-                    window.focus()
-                }
-
-                const onUp = () => {
-                    window.removeEventListener('mousemove', onMove)
-                    window.removeEventListener('mouseup', onUp)
-                    window.removeEventListener('mouseenter', onEnter)
-                    key.classList.remove('rotateLeft', 'rotateRight')
-                }
-
-                window.addEventListener('mouseenter', onEnter)
-                window.addEventListener('mousemove', onMove)
-                window.addEventListener('mouseup', onUp)
-            } else {
-                activeKeys.add(i)
-                sendKeyPress(i, 'down')
-            }
-        })
-
-        key.addEventListener('mouseup', () => {
-            activeKeys.delete(i)
-            sendKeyPress(i, 'up')
-        })
-
-        const onWheel = (wheelEvent) => {
-            wheelEvent.preventDefault()
-            const delta = wheelEvent.deltaY > 0 ? stepSize : -stepSize
-            handleDirection(delta)
-        }
-
-        key.addEventListener('wheel', onWheel, { passive: false })
-
-        // Add context menu again
-        key.addEventListener('contextmenu', (e) => showContextMenu(e, i))
+        // Minimum movement (px) before an encoder interaction is treated as
+        // a rotation drag rather than a press-and-release (see #45).
+        const dragThreshold = 8
 
         let accumulatedDeltaX = 0
 
@@ -579,6 +530,151 @@ window.addEventListener('DOMContentLoaded', () => {
                 }, 250)
             }
         }
+
+        // Shared press-vs-drag tracking for an encoder interaction, used by
+        // both the mouse and touch code paths below. A quick tap/click that
+        // doesn't move (much) is treated as a plain button press/release; an
+        // actual drag rotates the encoder, exactly as it did before (#45).
+        const startEncoderInteraction = (startX) => {
+            let lastX = startX
+            let totalMovement = 0
+            let dragStarted = false
+
+            const onMove = (currentX) => {
+                const deltaX = currentX - lastX
+                lastX = currentX
+                totalMovement += Math.abs(deltaX)
+
+                if (!dragStarted && totalMovement >= dragThreshold) {
+                    dragStarted = true
+                }
+
+                if (dragStarted) {
+                    handleDirection(deltaX)
+                }
+            }
+
+            const onEnd = () => {
+                key.classList.remove('rotateLeft', 'rotateRight')
+
+                if (!dragStarted) {
+                    sendKeyPress(i, 'down')
+                    sendKeyPress(i, 'up')
+                }
+            }
+
+            return { onMove, onEnd }
+        }
+
+        key.addEventListener('mousedown', (e) => {
+            if (e.button === 2) {
+                return
+            }
+
+            if (isEncoder) {
+                e.preventDefault()
+
+                const interaction = startEncoderInteraction(e.clientX)
+
+                const onMouseMove = (moveEvent) => {
+                    interaction.onMove(moveEvent.clientX)
+                }
+
+                const onEnter = () => {
+                    window.focus()
+                }
+
+                const onMouseUp = () => {
+                    window.removeEventListener('mousemove', onMouseMove)
+                    window.removeEventListener('mouseup', onMouseUp)
+                    window.removeEventListener('mouseenter', onEnter)
+                    interaction.onEnd()
+                }
+
+                window.addEventListener('mouseenter', onEnter)
+                window.addEventListener('mousemove', onMouseMove)
+                window.addEventListener('mouseup', onMouseUp)
+            } else {
+                activeKeys.add(i)
+                sendKeyPress(i, 'down')
+            }
+        })
+
+        key.addEventListener('mouseup', () => {
+            activeKeys.delete(i)
+            sendKeyPress(i, 'up')
+        })
+
+        // Touch support (#44, #50, #45): touchstart/touchmove/touchend mirror
+        // the mousedown/mousemove/mouseup handlers above. Calling
+        // preventDefault() on touchstart is what stops Chromium from
+        // synthesizing a long-press `contextmenu` event (which would
+        // otherwise pop open the key configuration menu on a normal
+        // press-and-hold instead of registering the press), and it also
+        // suppresses the synthetic mouse events Chromium/Electron would
+        // otherwise fire after the touch sequence, avoiding double-firing.
+        key.addEventListener(
+            'touchstart',
+            (e) => {
+                e.preventDefault()
+
+                const touch = e.touches[0]
+                if (!touch) {
+                    return
+                }
+
+                if (isEncoder) {
+                    const interaction = startEncoderInteraction(touch.clientX)
+
+                    const onTouchMove = (moveEvent) => {
+                        const moveTouch = moveEvent.touches[0]
+                        if (moveTouch) {
+                            interaction.onMove(moveTouch.clientX)
+                        }
+                    }
+
+                    const onTouchEnd = () => {
+                        window.removeEventListener('touchmove', onTouchMove)
+                        window.removeEventListener('touchend', onTouchEnd)
+                        window.removeEventListener('touchcancel', onTouchEnd)
+                        interaction.onEnd()
+                    }
+
+                    window.addEventListener('touchmove', onTouchMove, {
+                        passive: false,
+                    })
+                    window.addEventListener('touchend', onTouchEnd)
+                    window.addEventListener('touchcancel', onTouchEnd)
+                } else {
+                    activeKeys.add(i)
+                    sendKeyPress(i, 'down')
+                }
+            },
+            { passive: false }
+        )
+
+        key.addEventListener(
+            'touchend',
+            (e) => {
+                if (!isEncoder) {
+                    e.preventDefault()
+                    activeKeys.delete(i)
+                    sendKeyPress(i, 'up')
+                }
+            },
+            { passive: false }
+        )
+
+        const onWheel = (wheelEvent) => {
+            wheelEvent.preventDefault()
+            const delta = wheelEvent.deltaY > 0 ? stepSize : -stepSize
+            handleDirection(delta)
+        }
+
+        key.addEventListener('wheel', onWheel, { passive: false })
+
+        // Add context menu again
+        key.addEventListener('contextmenu', (e) => showContextMenu(e, i))
     }
 
     function closeContextMenu() {
@@ -848,6 +944,23 @@ window.addEventListener('DOMContentLoaded', () => {
     })
 
     window.addEventListener('blur', () => {
+        activeKeys.forEach((keyIndex) => {
+            sendKeyPress(keyIndex, 'up')
+        })
+        activeKeys.clear()
+    })
+
+    // Safety net mirroring the mouseup/blur handlers above, in case a touch
+    // sequence ends (or is cancelled by the system) without the per-key
+    // touchend handler firing, which would otherwise leave a key "stuck" down.
+    window.addEventListener('touchend', () => {
+        activeKeys.forEach((keyIndex) => {
+            sendKeyPress(keyIndex, 'up')
+        })
+        activeKeys.clear()
+    })
+
+    window.addEventListener('touchcancel', () => {
         activeKeys.forEach((keyIndex) => {
             sendKeyPress(keyIndex, 'up')
         })


### PR DESCRIPTION
## Summary

`bindKeyEvents()` in `public/index.js` is the only place key/encoder press, release, and rotation are wired up, and it only ever listened for `mousedown`/`mouseup`/`wheel`/`contextmenu`. There was no `touchstart`/`touchmove`/`touchend` handling at all, which caused three related issues:

- **#44** — Long press on a touchscreen popped open the right-click key configuration menu instead of registering a press. This happened because Chromium synthesizes a `contextmenu` event on a long touch-hold unless the touch's default is prevented. Fixed by calling `e.preventDefault()` immediately in the new `touchstart` handler.
- **#50** — Encoder drag-to-rotate never worked on touch, since the existing logic only read `clientX` from `mousemove`. Added `touchstart`/`touchmove`/`touchend` handlers that mirror the mouse path, reading `e.touches[0].clientX` instead.
- **#45** (feature request) — Real Stream Deck+ dials can be pressed like a button, separate from being turned. There was previously no way to "press" an encoder at all. Added a shared `startEncoderInteraction()` helper (used by both the mouse and touch code paths) that tracks total movement during the down→move→up interaction. If total movement stays under an 8px threshold, a normal `sendKeyPress(i, 'down')` / `sendKeyPress(i, 'up')` pair is sent instead of a rotation. If movement exceeds the threshold, it behaves exactly as the existing drag-to-rotate logic (rotation only, no press sent).

Also added `touchend`/`touchcancel` listeners at the window level, mirroring the existing `mouseup`/`blur` safety net, so a key can't get stuck "down" if a touch sequence is interrupted (e.g. cancelled by the system) without its per-key `touchend` firing.

All existing mouse/wheel/contextmenu behavior is unchanged — the touch handling is purely additive, and touch/mouse code paths are kept structurally separate (touch handlers don't simulate mouse events) to avoid double-firing risk, since `preventDefault()` on `touchstart` should already suppress Chromium's synthetic mouse event sequence on most platforms.

## Verification

- `node -c public/index.js` — valid syntax.
- `yarn build` (`tsc`) — passes with no errors.
- Launched the built app in the background (`yarn start`), confirmed no startup errors in logs, then killed all `screendeck`/Electron-helper processes and confirmed none remained (`ps aux | grep -i screendeck`).
- **Touch-hardware interaction cannot be verified in this environment** — there's no physical touchscreen or touch-emulation harness available here, so the `touchstart`/`touchmove`/`touchend` code paths are unverified against real touch input and should be tested on an actual touchscreen device before considering #44/#50 fully confirmed fixed.
- The press-vs-drag threshold logic (#45) was traced through manually instead, since it's pure JS logic independent of the input device:
  - Quick tap/click with ~0 movement: no `mousemove`/`touchmove` events cross the 8px threshold, so `dragStarted` stays `false`, and `onEnd()` sends `sendKeyPress(i, 'down')` + `sendKeyPress(i, 'up')` — a press, no rotation classes/events.
  - A 50px drag: total movement crosses the 8px threshold partway through, `dragStarted` becomes `true`, and all moves from that point are forwarded to the existing `handleDirection()` (unchanged rotation logic) — `onEnd()` sees `dragStarted === true` and does not send a press.

## Test plan

- [ ] Manually verify on a touchscreen device: press-and-hold a normal button no longer opens the context menu, and registers as a normal press/release (#44).
- [ ] Manually verify dragging a finger across an encoder key rotates it (#50).
- [ ] Manually verify a quick tap on an encoder key sends a press, and a real drag still rotates without also sending a press (#45).
- [ ] Confirm desktop mouse/wheel/right-click behavior is unaffected.

Fixes #44, #50, #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)