### PR TITLE
Fix #47: refresh device windows on wake from sleep

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow } from 'electron'
+import { app, BrowserWindow, powerMonitor } from 'electron'
 import type { CompanionSatelliteClient } from './client' // Your new client class
 import { initializeIpcHandlers } from './ipcHandlers' // Import IPC handlers
 import createTray from './tray' // Import the tray creation function
@@ -94,5 +94,15 @@ app.whenReady().then(() => {
 
     app.on('quit', () => {
         console.log('App has quit.')
+    })
+
+    powerMonitor.on('resume', () => {
+        console.log('System resumed from sleep, refreshing device windows...')
+        global.deviceWindows.forEach((win) => {
+            if (win.isVisible()) {
+                win.hide()
+                win.show()
+            }
+        })
     })
 })


### PR DESCRIPTION
## Summary

Fixes #47 — on Windows, after the PC goes to sleep and wakes up, ScreenDeck's device windows stop rendering, and toggling hide/show from the tray menu does not fix it. Users currently have to fully quit and restart the app.

This is a well-known Electron-on-Windows issue: `BrowserWindow`s can lose their GPU/rendering context across a system sleep/resume cycle and need to be nudged to force a repaint.

## Fix

- Import `powerMonitor` from `electron` in `src/main.ts`.
- Register a `powerMonitor.on('resume', ...)` listener (alongside the other `app.on(...)` registrations in `app.whenReady().then(...)`) that iterates `global.deviceWindows` and, for each window that is currently visible, calls `win.hide()` followed by `win.show()`. This forces Chromium to fully repaint the window's contents, which is the standard workaround for the GPU-context-loss-on-resume issue.

The change is minimal and intentionally does not touch any other lifecycle/init code.

## Test plan

- [x] `yarn build` (`tsc`) compiles with no errors.
- [x] Sanity check: launched the built app locally (`electron .`), confirmed device windows are created and rendered correctly, no startup errors in logs, then cleanly shut it down.
- [ ] **Needs real-machine verification**: this fix can only be fully confirmed by actually putting a Windows PC to sleep and waking it up, since the bug is specific to the Windows Electron/GPU driver interaction described in the issue. I was not able to reproduce/verify the actual sleep/resume scenario in this environment (macOS, no ability to trigger a real system sleep/resume cycle). Would appreciate a test on real Windows hardware before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)