### PR TITLE
Fix Windows resize leaving buffer around buttons (#33)

### DIFF
--- a/src/device.ts
+++ b/src/device.ts
@@ -214,12 +214,18 @@ export function resizeWindowForDevice(deviceId: string) {
             deviceConfig.rowCount || 4,
             bitmapSize
         )
+        // On Windows, BrowserWindow.setBounds() can behave unreliably on
+        // resizable: false windows, sometimes only applying one axis of the
+        // resize (see #33). Temporarily allow resizing around the call as a
+        // workaround.
+        win.setResizable(true)
         win.setBounds({
             width,
             height,
             x: win.getBounds().x,
             y: win.getBounds().y,
         })
+        win.setResizable(false)
         return
     }
 
@@ -249,10 +255,16 @@ export function resizeWindowForDevice(deviceId: string) {
         `[Resize] ${deviceId}: ${visibleCols} cols x ${visibleRows} rows → ${width}x${height}`
     )
 
+    // On Windows, BrowserWindow.setBounds() can behave unreliably on
+    // resizable: false windows, sometimes only applying one axis of the
+    // resize (see #33). Temporarily allow resizing around the call as a
+    // workaround.
+    win.setResizable(true)
     win.setBounds({
         width,
         height,
         x: win.getBounds().x,
         y: win.getBounds().y,
     })
+    win.setResizable(false)
 }

--- a/src/ipcHandlers.ts
+++ b/src/ipcHandlers.ts
@@ -82,7 +82,13 @@ function applyDeviceConfig(deviceId: string, config: Record<string, any>) {
                 bitmapSize
             )
 
+            // On Windows, BrowserWindow.setSize() can behave unreliably on
+            // resizable: false windows, sometimes only applying one axis of
+            // the resize (see #33). Temporarily allow resizing around the
+            // call as a workaround.
+            win.setResizable(true)
             win.setSize(width, height)
+            win.setResizable(false)
 
             // If the Satellite client is connected and key properties changed, update the device config
             if (global.satelliteClient) {


### PR DESCRIPTION
## Summary

Fixes the bug reported in #33: reducing the per-device `bitmapSize` setting in Settings only shrinks the device window's height on Windows, not its width, leaving gray empty space/borders on the sides of the buttons until the app is restarted.

## Root cause

On Windows, `BrowserWindow.setSize()` / `BrowserWindow.setBounds()` can behave unreliably on windows created with `resizable: false`, sometimes only applying one axis of the resize. This is a known, documented Electron/Windows quirk. Device windows in this app are always created with `resizable: false` (see `createDeviceWindow()` in `src/device.ts`), so any live resize triggered by changing `columnCount`/`rowCount`/`bitmapSize` in Settings is affected:

- `applyDeviceConfig()` in `src/ipcHandlers.ts` (shared by the `updateDeviceConfig` and `resetDeviceToDefaults` IPC handlers) calls `win.setSize(width, height)`.
- `resizeWindowForDevice()` in `src/device.ts` (used by the "hide empty keys" live-resize feature) calls `win.setBounds({ width, height, ... })` in two places.

Restarting the app recreates the window fresh at the correct size, which is why users only saw the bug on the live update, not after a restart.

## Fix

Applied the standard, well-documented workaround at each of the three call sites: temporarily flip the window to resizable immediately around the resize call, then flip it back to non-resizable afterward:

```ts
win.setResizable(true)
win.setSize(width, height)   // or win.setBounds({...})
win.setResizable(false)
```

No other logic was changed (the `needsDeviceUpdate` change-detection, satellite re-add logic, etc. are untouched).

## Verification

- `yarn build` (`tsc`) compiles with no errors.
- Sanity-launched the built app locally (macOS) to confirm window creation/resize still works end-to-end (device window created, satellite connected, window shown) — no regressions observed.
- **This specific bug is Windows-only and could not be interactively reproduced/verified in this environment (macOS).** The fix is the standard, well-documented workaround for this known Electron/Windows behavior, so it's reasonable to ship for review, but it needs a Windows user to confirm the fix resolves the reported symptom before we consider #33 fully closed.

Ref #33