### PR TITLE
Add general-purpose app hotkeys: show/hide all decks, show/hide one device

### DIFF
--- a/public/hotkeyPrompt.html
+++ b/public/hotkeyPrompt.html
@@ -72,8 +72,7 @@
         <button id="closeButton" class="close-button-settings">×</button>
         <h2>Assign Hotkey</h2>
         <div id="keyPreview"></div>
-        <div><strong>Device:</strong> <span id="deviceId"></span></div>
-        <div><strong>Key:</strong> <span id="keyIndex"></span></div>
+        <div><strong>Assigning hotkey for:</strong> <span id="targetDescription"></span></div>
 
         <div class="modifiers">
             <button data-mod="Ctrl">Ctrl</button>
@@ -99,8 +98,7 @@
                 <tr>
                     <th>&nbsp;</th>
                     <th>Hotkey</th>
-                    <th>Device</th>
-                    <th>Key</th>
+                    <th>Assigned To</th>
                     <th>Action</th>
                 </tr>
             </thead>

--- a/public/hotkeyPrompt.js
+++ b/public/hotkeyPrompt.js
@@ -1,9 +1,18 @@
 window.addEventListener('DOMContentLoaded', () => {
     let modifiers = new Set()
     let primaryKey = ''
-    let deviceId = ''
-    let keyIndex = ''
+    let context = null // the HotkeyBinding this prompt is assigning: {kind, deviceId?, keyIndex?}
     let currentHotkeys = []
+
+    function describeBinding(binding) {
+        if (binding.kind === 'toggleAll') {
+            return 'Show/Hide All Screen Decks'
+        }
+        if (binding.kind === 'toggleDevice') {
+            return `Show/Hide ${binding.deviceId}`
+        }
+        return `Key ${binding.keyIndex} on ${binding.deviceId}`
+    }
 
     function showHotkeyError(message) {
         const errorEl = document.getElementById('hotkeyError')
@@ -23,17 +32,23 @@ window.addEventListener('DOMContentLoaded', () => {
 
     // Get initial data
     window.electronAPI.getHotkeyContext().then((data) => {
-        deviceId = data.deviceId
-        keyIndex = data.keyIndex
+        context = {
+            kind: data.kind,
+            deviceId: data.deviceId,
+            keyIndex: data.keyIndex,
+        }
 
-        document.getElementById('deviceId').textContent = deviceId
-        document.getElementById('keyIndex').textContent = keyIndex
+        document.getElementById('targetDescription').textContent =
+            describeBinding(context)
 
-        // If there's a bitmap, show it
+        // If there's a bitmap (per-key hotkeys only), show it
         const keyPreview = document.getElementById('keyPreview')
         keyPreview.innerHTML = '' // Clear previous content
-        if (data.imageBase64) {
+        if (data.kind === 'key' && data.imageBase64) {
+            keyPreview.style.display = 'block'
             renderBitmap(keyPreview, data.imageBase64)
+        } else {
+            keyPreview.style.display = 'none'
         }
 
         // Load current hotkeys
@@ -67,6 +82,17 @@ window.addEventListener('DOMContentLoaded', () => {
         document.getElementById('hotkeyPreview').textContent = fullHotkey
     }
 
+    // Is `h` (an entry from currentHotkeys) bound to the exact same target
+    // this prompt is currently assigning? Used to exclude "self" when
+    // checking for conflicts (re-assigning a key its own hotkey isn't a
+    // conflict).
+    function isSameTarget(h) {
+        if (h.kind !== context.kind) return false
+        if (h.kind === 'toggleAll') return true
+        if (h.kind === 'toggleDevice') return h.deviceId === context.deviceId
+        return h.deviceId === context.deviceId && h.keyIndex === context.keyIndex
+    }
+
     function updateHotkeyList(hotkeys) {
         currentHotkeys = hotkeys || []
 
@@ -76,7 +102,7 @@ window.addEventListener('DOMContentLoaded', () => {
         hotkeys.forEach((h) => {
             const tr = document.createElement('tr')
 
-            // Create a cell for the bitmap canvas
+            // Create a cell for the bitmap canvas (per-key hotkeys only)
             const tdCanvas = document.createElement('td')
             const container = document.createElement('div')
             container.style.width = '32px'
@@ -85,7 +111,7 @@ window.addEventListener('DOMContentLoaded', () => {
             container.style.verticalAlign = 'middle'
             tdCanvas.appendChild(container)
 
-            if (h.imageBase64) {
+            if (h.kind === 'key' && h.imageBase64) {
                 renderBitmap(container, h.imageBase64)
             }
 
@@ -96,13 +122,9 @@ window.addEventListener('DOMContentLoaded', () => {
             tdHotkey.textContent = h.hotkey
             tr.appendChild(tdHotkey)
 
-            const tdDeviceId = document.createElement('td')
-            tdDeviceId.textContent = h.deviceId
-            tr.appendChild(tdDeviceId)
-
-            const tdKeyIndex = document.createElement('td')
-            tdKeyIndex.textContent = h.keyIndex
-            tr.appendChild(tdKeyIndex)
+            const tdTarget = document.createElement('td')
+            tdTarget.textContent = describeBinding(h)
+            tr.appendChild(tdTarget)
 
             // Add Clear button
             const tdButton = document.createElement('td')
@@ -111,6 +133,7 @@ window.addEventListener('DOMContentLoaded', () => {
             btn.addEventListener('click', () => {
                 window.electronAPI
                     .clearHotkey({
+                        kind: h.kind,
                         deviceId: h.deviceId,
                         keyIndex: h.keyIndex,
                         hotkey: h.hotkey,
@@ -141,25 +164,22 @@ window.addEventListener('DOMContentLoaded', () => {
 
         const hotkeyStr = Array.from(modifiers).join('+') + `+${primaryKey}`
 
-        // Proactively check for conflicts with other keys/devices before
-        // even asking the main process to register the hotkey.
+        // Proactively check for conflicts with other targets before even
+        // asking the main process to register the hotkey.
         const conflict = currentHotkeys.find(
-            (h) =>
-                h.hotkey === hotkeyStr &&
-                (h.deviceId !== deviceId || h.keyIndex !== keyIndex)
+            (h) => h.hotkey === hotkeyStr && !isSameTarget(h)
         )
 
         if (conflict) {
             showHotkeyError(
-                `${hotkeyStr} is already assigned to key ${conflict.keyIndex} on ${conflict.deviceId}`
+                `${hotkeyStr} is already assigned to ${describeBinding(conflict)}`
             )
             return
         }
 
         window.electronAPI
             .assignHotkey({
-                deviceId,
-                keyIndex,
+                ...context,
                 hotkey: hotkeyStr,
             })
             .then((success) => {

--- a/public/index.js
+++ b/public/index.js
@@ -415,6 +415,7 @@ window.addEventListener('DOMContentLoaded', () => {
                 let keyConfig = keyStates.get(deviceId)?.get(keyIndex)
                 let imageBase64 = keyConfig?.imageBase64 || null
                 window.electronAPI.setHotkeyContext({
+                    kind: 'key',
                     deviceId,
                     keyIndex,
                     imageBase64,

--- a/public/settings.html
+++ b/public/settings.html
@@ -93,6 +93,11 @@
 
             <hr />
 
+            <h2>App Hotkeys</h2>
+            <div id="appHotkeys"></div>
+
+            <hr />
+
             <button id="addDevice">+ Add New ScreenDeck</button>
 
             <div id="deviceList"></div>

--- a/public/settings.js
+++ b/public/settings.js
@@ -4,6 +4,14 @@ window.addEventListener('DOMContentLoaded', () => {
 
     loadCompanionSettings()
     loadDevices()
+    loadAppHotkeys()
+
+    // The hotkey-assignment prompt is a separate modal window; when it
+    // closes, focus returns here. Refresh so any newly assigned/cleared
+    // hotkey shows up without requiring a manual reopen of Settings.
+    window.addEventListener('focus', () => {
+        loadAppHotkeys()
+    })
 
     document
         .getElementById('saveCompanion')
@@ -255,6 +263,78 @@ window.addEventListener('DOMContentLoaded', () => {
             container.appendChild(actions)
             deviceList.appendChild(container)
         })
+    }
+
+    async function loadAppHotkeys() {
+        const appHotkeysContainer = document.getElementById('appHotkeys')
+        appHotkeysContainer.innerHTML = ''
+
+        const [settings, devices] = await Promise.all([
+            window.electronAPI.getSettings(),
+            window.electronAPI.getAllDevices(),
+        ])
+
+        appHotkeysContainer.appendChild(
+            createHotkeyRow(
+                'Show/Hide All Screen Decks',
+                settings.appHotkeys?.toggleAll,
+                { kind: 'toggleAll' }
+            )
+        )
+
+        devices.forEach((device) => {
+            appHotkeysContainer.appendChild(
+                createHotkeyRow(
+                    `Show/Hide ${device.name || device.deviceId}`,
+                    device.toggleHotkey,
+                    { kind: 'toggleDevice', deviceId: device.deviceId }
+                )
+            )
+        })
+    }
+
+    // Builds one "Set/Clear a global hotkey" row, reusing the same
+    // hotkey-assignment prompt window used for per-key hotkeys.
+    function createHotkeyRow(labelText, currentHotkey, context) {
+        const row = document.createElement('div')
+        row.style.display = 'flex'
+        row.style.alignItems = 'center'
+        row.style.gap = '8px'
+        row.style.marginBottom = '6px'
+
+        const label = document.createElement('span')
+        label.style.flex = '1'
+        label.textContent = labelText
+        row.appendChild(label)
+
+        const hotkeyLabel = document.createElement('span')
+        hotkeyLabel.style.fontFamily = 'monospace'
+        hotkeyLabel.style.color = currentHotkey ? '#000' : '#999'
+        hotkeyLabel.textContent = currentHotkey || 'Not set'
+        row.appendChild(hotkeyLabel)
+
+        const setBtn = document.createElement('button')
+        setBtn.textContent = currentHotkey ? 'Change' : 'Set'
+        setBtn.addEventListener('click', async () => {
+            await window.electronAPI.setHotkeyContext(context)
+            await window.electronAPI.openHotkeyPrompt()
+        })
+        row.appendChild(setBtn)
+
+        if (currentHotkey) {
+            const clearBtn = document.createElement('button')
+            clearBtn.textContent = 'Clear'
+            clearBtn.addEventListener('click', async () => {
+                await window.electronAPI.clearHotkey({
+                    ...context,
+                    hotkey: currentHotkey,
+                })
+                loadAppHotkeys()
+            })
+            row.appendChild(clearBtn)
+        }
+
+        return row
     }
 
     function createCheckbox(labelText, checked) {

--- a/src/device.ts
+++ b/src/device.ts
@@ -155,6 +155,58 @@ export function showWindows(ignoreHiddenState = false) {
     console.log('All device windows shown')
 }
 
+// Hide every device window, persisting the hidden state for each.
+export function hideAllDeviceWindows() {
+    global.deviceWindows.forEach((win, deviceId) => {
+        if (win.isVisible()) {
+            win.hide()
+            store.set(`device.${deviceId}.hidden`, true)
+        }
+    })
+    updateTrayMenu()
+}
+
+// Show every device window, persisting the hidden state for each.
+export function showAllDeviceWindows() {
+    global.deviceWindows.forEach((win, deviceId) => {
+        if (!win.isVisible()) {
+            win.show()
+            store.set(`device.${deviceId}.hidden`, false)
+        }
+    })
+    updateTrayMenu()
+}
+
+// Toggles all device windows based on aggregate visibility: if any window is
+// currently visible, hide all of them; otherwise show all of them. Used by
+// the "Show/Hide All" app-level hotkey (issue #38).
+export function toggleAllDeviceWindows() {
+    const anyVisible = Array.from(global.deviceWindows.values()).some((win) =>
+        win.isVisible()
+    )
+    if (anyVisible) {
+        hideAllDeviceWindows()
+    } else {
+        showAllDeviceWindows()
+    }
+}
+
+// Toggles a single device window's visibility. Used by the per-device
+// "Show/Hide" app-level hotkey (issue #38).
+export function toggleDeviceWindow(deviceId: string) {
+    const win = global.deviceWindows.get(deviceId)
+    if (!win) return
+
+    if (win.isVisible()) {
+        win.hide()
+        store.set(`device.${deviceId}.hidden`, true)
+    } else {
+        win.show()
+        store.set(`device.${deviceId}.hidden`, false)
+    }
+    updateTrayMenu()
+}
+
 // Show or hide device labels in all windows
 export function showDeviceLabels(show: boolean) {
     global.deviceWindows.forEach((win, deviceId) => {

--- a/src/hotkeys.ts
+++ b/src/hotkeys.ts
@@ -1,5 +1,15 @@
 import { globalShortcut } from 'electron'
 import { store } from './store'
+import { toggleAllDeviceWindows, toggleDeviceWindow } from './device'
+
+// A registered global hotkey is bound to one of three kinds of action:
+// - 'key': sends a Companion key press/release, exactly like clicking the key
+// - 'toggleAll': shows/hides every device window
+// - 'toggleDevice': shows/hides one specific device window
+export type HotkeyBinding =
+    | { kind: 'key'; deviceId: string; keyIndex: number; imageBase64: string }
+    | { kind: 'toggleAll' }
+    | { kind: 'toggleDevice'; deviceId: string }
 
 export function registerHotkey(
     hotkey: string,
@@ -39,6 +49,7 @@ export function registerHotkey(
         }
 
         global.registeredHotkeys.set(hotkey, {
+            kind: 'key',
             deviceId,
             keyIndex,
             imageBase64,
@@ -46,6 +57,52 @@ export function registerHotkey(
         console.log(
             `Registered hotkey: ${hotkey} for ${deviceId} key ${keyIndex}`
         )
+        return true
+    } catch (error) {
+        console.error(`Failed to register hotkey ${hotkey}:`, error)
+        return false
+    }
+}
+
+export function registerToggleAllHotkey(hotkey: string): boolean {
+    if (globalShortcut.isRegistered(hotkey)) {
+        console.warn(`Hotkey ${hotkey} is already in use`)
+        return false
+    }
+
+    try {
+        globalShortcut.register(hotkey, () => {
+            toggleAllDeviceWindows()
+        })
+
+        global.registeredHotkeys.set(hotkey, { kind: 'toggleAll' })
+        console.log(`Registered hotkey: ${hotkey} for Show/Hide All`)
+        return true
+    } catch (error) {
+        console.error(`Failed to register hotkey ${hotkey}:`, error)
+        return false
+    }
+}
+
+export function registerToggleDeviceHotkey(
+    hotkey: string,
+    deviceId: string
+): boolean {
+    if (globalShortcut.isRegistered(hotkey)) {
+        console.warn(`Hotkey ${hotkey} is already in use`)
+        return false
+    }
+
+    try {
+        globalShortcut.register(hotkey, () => {
+            toggleDeviceWindow(deviceId)
+        })
+
+        global.registeredHotkeys.set(hotkey, {
+            kind: 'toggleDevice',
+            deviceId,
+        })
+        console.log(`Registered hotkey: ${hotkey} for Show/Hide ${deviceId}`)
         return true
     } catch (error) {
         console.error(`Failed to register hotkey ${hotkey}:`, error)
@@ -62,8 +119,11 @@ export function unregisterHotkey(hotkey: string) {
 }
 
 export function unregisterAllHotkeysForDevice(deviceId: string) {
-    for (const [hotkey, mapping] of global.registeredHotkeys.entries()) {
-        if (mapping.deviceId === deviceId) {
+    for (const [hotkey, binding] of global.registeredHotkeys.entries()) {
+        if (
+            (binding.kind === 'key' || binding.kind === 'toggleDevice') &&
+            binding.deviceId === deviceId
+        ) {
             unregisterHotkey(hotkey)
         }
     }
@@ -80,11 +140,15 @@ export function isHotkeyConflict(
     deviceId: string,
     keyIndex: number
 ): boolean {
-    const mapping = global.registeredHotkeys.get(hotkey)
-    if (!mapping) return false
+    const binding = global.registeredHotkeys.get(hotkey)
+    if (!binding) return false
 
-    // If it's already mapped to this key, no problem
-    if (mapping.deviceId === deviceId && mapping.keyIndex === keyIndex)
+    // If it's already mapped to this same key, no problem
+    if (
+        binding.kind === 'key' &&
+        binding.deviceId === deviceId &&
+        binding.keyIndex === keyIndex
+    )
         return false
 
     return true
@@ -93,6 +157,14 @@ export function isHotkeyConflict(
 // Reload all hotkeys from the store at startup
 export function loadHotkeysFromStore() {
     const deviceIds = store.get('deviceIds', []) as string[]
+
+    const toggleAllHotkey = store.get('appHotkeys.toggleAll') as
+        | string
+        | undefined
+    if (toggleAllHotkey) {
+        registerToggleAllHotkey(toggleAllHotkey)
+    }
+
     for (const deviceId of deviceIds) {
         const keys = store.get(`device.${deviceId}.keys`, {}) as Record<
             string,
@@ -104,6 +176,13 @@ export function loadHotkeysFromStore() {
                 const hotkey = keyConfig.hotkey
                 registerHotkey(hotkey, deviceId, keyIndex)
             }
+        }
+
+        const toggleDeviceHotkey = store.get(
+            `device.${deviceId}.toggleHotkey`
+        ) as string | undefined
+        if (toggleDeviceHotkey) {
+            registerToggleDeviceHotkey(toggleDeviceHotkey, deviceId)
         }
     }
 }

--- a/src/ipcHandlers.ts
+++ b/src/ipcHandlers.ts
@@ -5,6 +5,8 @@ import { updateTrayMenu } from './tray'
 
 import {
     registerHotkey,
+    registerToggleAllHotkey,
+    registerToggleDeviceHotkey,
     unregisterHotkey,
     unregisterAllHotkeysForDevice,
 } from './hotkeys' // Import the hotkey registration function
@@ -308,38 +310,27 @@ export function initializeIpcHandlers() {
     })
 
     //HOTKEYS
-    ipcMain.handle(
-        'setHotkeyContext',
-        (_event, { deviceId, keyIndex, imageBase64 }) => {
-            global.hotkeyContext = { deviceId, keyIndex, imageBase64 }
-        }
-    )
+    ipcMain.handle('setHotkeyContext', (_event, context) => {
+        global.hotkeyContext = context
+    })
 
-    // Get key context for the hotkey prompt
+    // Get the current context for the hotkey prompt (what's being assigned:
+    // a specific key, "show/hide all", or "show/hide one device")
     ipcMain.handle('getHotkeyContext', (_event) => {
-        const context = global.hotkeyContext // deviceId, keyIndex, imageBase64
+        const context = global.hotkeyContext
 
         if (!context) {
             return undefined
         }
 
-        const { deviceId, keyIndex, imageBase64 } = context
-
-        // Get list of current hotkeys
+        // Get list of current hotkeys, of every kind
         const hotkeys = []
-        for (const [hotkey, mapping] of global.registeredHotkeys.entries()) {
-            hotkeys.push({
-                hotkey,
-                deviceId: mapping.deviceId,
-                keyIndex: mapping.keyIndex,
-                imageBase64: mapping.imageBase64,
-            })
+        for (const [hotkey, binding] of global.registeredHotkeys.entries()) {
+            hotkeys.push({ hotkey, ...binding })
         }
 
         return {
-            deviceId,
-            keyIndex,
-            imageBase64,
+            ...context,
             currentHotkeys: hotkeys,
         }
     })
@@ -395,30 +386,56 @@ export function initializeIpcHandlers() {
         }
     })
 
-    // Handle assignHotkey
-    ipcMain.handle('assignHotkey', (_event, { deviceId, keyIndex, hotkey }) => {
-        const columnCount = store.get(`device.${deviceId}.columnCount`, 8)
-        const x = keyIndex % columnCount
-        const y = Math.floor(keyIndex / columnCount)
+    // Handle assignHotkey - the payload is a HotkeyBinding plus the chosen
+    // hotkey string, covering per-key hotkeys as well as the "show/hide all"
+    // and "show/hide one device" app-level hotkeys (issue #38)
+    ipcMain.handle('assignHotkey', (_event, { hotkey, ...context }) => {
+        let success = false
 
-        // Register in hotkeys.ts
-        const success = registerHotkey(hotkey, deviceId, keyIndex)
-        if (success) {
-            // Save to store
-            const keyConfig = store.get(
-                `device.${deviceId}.keys`,
-                {}
-            ) as Record<number, { hotkey?: string }>
-            keyConfig[keyIndex] = { ...(keyConfig[keyIndex] || {}), hotkey }
-            store.set(`device.${deviceId}.keys`, keyConfig)
+        if (context.kind === 'key') {
+            const { deviceId, keyIndex } = context
+            success = registerHotkey(hotkey, deviceId, keyIndex)
+            if (success) {
+                const keyConfig = store.get(
+                    `device.${deviceId}.keys`,
+                    {}
+                ) as Record<number, { hotkey?: string }>
+                keyConfig[keyIndex] = {
+                    ...(keyConfig[keyIndex] || {}),
+                    hotkey,
+                }
+                store.set(`device.${deviceId}.keys`, keyConfig)
+            }
+        } else if (context.kind === 'toggleAll') {
+            success = registerToggleAllHotkey(hotkey)
+            if (success) {
+                store.set('appHotkeys.toggleAll', hotkey)
+            }
+        } else if (context.kind === 'toggleDevice') {
+            const { deviceId } = context
+            success = registerToggleDeviceHotkey(hotkey, deviceId)
+            if (success) {
+                store.set(`device.${deviceId}.toggleHotkey`, hotkey)
+            }
         }
 
         return success
     })
 
-    ipcMain.handle('clearHotkey', (_event, { deviceId, keyIndex, hotkey }) => {
+    ipcMain.handle('clearHotkey', (_event, { hotkey, ...context }) => {
         unregisterHotkey(hotkey)
 
+        if (context.kind === 'toggleAll') {
+            store.delete('appHotkeys.toggleAll' as any)
+            return true
+        }
+
+        if (context.kind === 'toggleDevice') {
+            store.delete(`device.${context.deviceId}.toggleHotkey` as any)
+            return true
+        }
+
+        const { deviceId, keyIndex } = context
         const keyConfig = store.get(`device.${deviceId}.keys`, {}) as Record<
             number,
             { hotkey?: string }
@@ -474,6 +491,7 @@ export function initializeIpcHandlers() {
         return deviceIds.map((id) => ({
             deviceId: id,
             name: store.get(`device.${id}.name`, 'ScreenDeck'),
+            toggleHotkey: store.get(`device.${id}.toggleHotkey`, null),
             columnCount: store.get(`device.${id}.columnCount`, 8),
             rowCount: store.get(`device.${id}.rowCount`, 4),
             bitmapSize: store.get(`device.${id}.bitmapSize`, 72),

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { initializeDeviceIds, createSatellite } from './utils' // Import utility
 
 import { createDeviceWindows } from './device' // Import device window creation
 
-import { loadHotkeysFromStore } from './hotkeys'
+import { loadHotkeysFromStore, HotkeyBinding } from './hotkeys'
 
 declare global {
     var satelliteClient: CompanionSatelliteClient | null
@@ -25,15 +25,8 @@ declare global {
         >
     >
     var hotkeyPromptWindow: BrowserWindow | null
-    var hotkeyContext: {
-        deviceId: string
-        keyIndex: number
-        imageBase64: string
-    } | null
-    var registeredHotkeys: Map<
-        string,
-        { deviceId: string; keyIndex: number; imageBase64: string }
-    >
+    var hotkeyContext: HotkeyBinding | null
+    var registeredHotkeys: Map<string, HotkeyBinding>
     var trayParentWindow: BrowserWindow
     var settingsWindow: BrowserWindow | null
     var isQuitting: boolean

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -10,6 +10,7 @@ import {
 import { ProfilesStore } from './types' // Import the ProfilesStore type
 
 import { unregisterAllHotkeys } from './hotkeys' // Import hotkey management functions
+import { hideAllDeviceWindows, showAllDeviceWindows } from './device'
 import { store } from './store'
 
 let tray: Tray | null = null
@@ -62,26 +63,14 @@ function updateTrayMenu() {
             label: `Hide All Screen Decks`,
             type: 'normal',
             click: () => {
-                global.deviceWindows.forEach((win, deviceId) => {
-                    if (win.isVisible()) {
-                        win.hide()
-                        store.set(`device.${deviceId}.hidden`, true)
-                    }
-                })
-                updateTrayMenu()
+                hideAllDeviceWindows()
             },
         },
         {
             label: `Show All Screen Decks`,
             type: 'normal',
             click: () => {
-                global.deviceWindows.forEach((win, deviceId) => {
-                    if (!win.isVisible()) {
-                        win.show()
-                        store.set(`device.${deviceId}.hidden`, false)
-                    }
-                })
-                updateTrayMenu()
+                showAllDeviceWindows()
             },
         },
         { type: 'separator' },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -127,6 +127,7 @@ export function createSatellite() {
         // If this key is a registered hotkey, update its bitmap reference too
         for (const [hotkey, mapping] of global.registeredHotkeys.entries()) {
             if (
+                mapping.kind === 'key' &&
                 mapping.deviceId === data.deviceId &&
                 mapping.keyIndex === data.keyIndex
             ) {


### PR DESCRIPTION
## Summary
- Implements issue #38: "Add some hotkeys for general purpose Screendeck use such as: show/hide all windows, show/hide window 1, 2, 3, etc."
- Design decisions (see the approved plan): per-device rather than fixed numeric slots (devices have generated IDs, not fixed positions), and one **toggle** hotkey per target rather than separate show/hide hotkeys.
- Generalizes the existing per-key hotkey machinery to a discriminated `HotkeyBinding` (`kind: 'key' | 'toggleAll' | 'toggleDevice'`) so per-key Companion hotkeys and the two new app-level hotkeys share one global-shortcut namespace, one conflict-detection pool, and the same already-working Assign Hotkey prompt window (extended to skip the bitmap preview and show a text description for non-key targets).
- New `toggleAllDeviceWindows()`/`toggleDeviceWindow()`/`showAllDeviceWindows()`/`hideAllDeviceWindows()` in `src/device.ts`; `src/tray.ts`'s existing Hide All/Show All menu items now call the shared functions instead of duplicating the loop.
- New "App Hotkeys" section in Settings: one row for "Show/Hide All Screen Decks" and one row per device, each with Set/Clear buttons.
- Deleting a device now also cleans up its toggle hotkey (reuses the existing `unregisterAllHotkeysForDevice` cleanup call, extended to match the new binding kind).

## Test plan
- [x] `tsc` build passes
- [x] All three renderer JS files syntax-check clean
- [x] Full cross-check: every `window.electronAPI.*` call resolves to a defined `preload.ts` method (no new methods needed — reused existing ones)
- [x] Live-launched the built app against a real running Companion instance, then used CDP (`Runtime.evaluate` over the renderer's websocket debugger) to exercise the real IPC pipeline end-to-end:
  - `setHotkeyContext`/`getHotkeyContext` correctly return the discriminated context + the full current-hotkeys list (verified the pre-existing per-key hotkey `Ctrl+1` still round-trips unchanged)
  - `assignHotkey` for both `toggleAll` and `toggleDevice` succeeds and persists (`appHotkeys.toggleAll`, `device.<id>.toggleHotkey`)
  - `clearHotkey` for both correctly unregisters and clears the store, without touching the pre-existing per-key hotkey
  - Confirmed no test artifacts were left in the real config file afterward
- [ ] Could not simulate an actual OS-level global-hotkey keypress from this environment (no input-injection tool available) — the registration mechanism (`globalShortcut.register`) is identical to the pre-existing, already-working per-key hotkey system, just with a different callback body, so this is a reasoned extrapolation rather than a directly observed trigger. Manual confirmation that pressing the assigned combo actually toggles the window(s) is worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)