### PR TITLE
Add per-key vertical encoder drag mode

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -306,6 +306,7 @@ window.addEventListener('DOMContentLoaded', () => {
         menu.innerHTML = `
     <div class="menu-item" data-action="encoder">Set to Encoder Mode</div>
     <div class="menu-item" data-action="set-step-size">Set Step Size...</div>
+    <div class="menu-item" data-action="toggle-encoder-axis">Toggle Vertical/Horizontal Drag</div>
     <div class="menu-item" data-action="button">Set to Button Mode (Normal)</div>
     <div class="menu-item" data-action="button-sticky">Set to Sticky Button Mode</div>
     <div class="menu-item" data-action="clear-sticky">Clear Sticky Mode</div>
@@ -391,6 +392,23 @@ window.addEventListener('DOMContentLoaded', () => {
                                     isEncoder: current.isEncoder,
                                     isSticky: current.isSticky,
                                     stepSize,
+                                },
+                            })
+                            .then(() => refreshKey(deviceId, keyIndex))
+                    })
+            } else if (action === 'toggle-encoder-axis') {
+                window.electronAPI
+                    .getKeyConfig({ deviceId, keyIndex })
+                    .then((current) => {
+                        window.electronAPI
+                            .updateKeyConfig({
+                                deviceId,
+                                keyIndex,
+                                config: {
+                                    isEncoder: current.isEncoder,
+                                    isSticky: current.isSticky,
+                                    stepSize: current.stepSize,
+                                    verticalEncoder: !current.verticalEncoder,
                                 },
                             })
                             .then(() => refreshKey(deviceId, keyIndex))
@@ -494,6 +512,14 @@ window.addEventListener('DOMContentLoaded', () => {
     function bindKeyEvents(key, i, keyConfig) {
         const isEncoder = keyConfig.isEncoder
         const stepSize = keyConfig.stepSize || 10
+        // When enabled, dragging up/down rotates the encoder instead of
+        // left/right (#46). Dragging up increases (rotateRight), dragging
+        // down decreases (rotateLeft) - negating clientY makes "up" produce
+        // a positive delta, matching the same sign convention horizontal
+        // drag already uses.
+        const verticalEncoder = keyConfig.verticalEncoder || false
+        const getAxisValue = (clientX, clientY) =>
+            verticalEncoder ? -clientY : clientX
         // Minimum movement (px) before an encoder interaction is treated as
         // a rotation drag rather than a press-and-release (see #45).
         const dragThreshold = 8
@@ -574,10 +600,14 @@ window.addEventListener('DOMContentLoaded', () => {
             if (isEncoder) {
                 e.preventDefault()
 
-                const interaction = startEncoderInteraction(e.clientX)
+                const interaction = startEncoderInteraction(
+                    getAxisValue(e.clientX, e.clientY)
+                )
 
                 const onMouseMove = (moveEvent) => {
-                    interaction.onMove(moveEvent.clientX)
+                    interaction.onMove(
+                        getAxisValue(moveEvent.clientX, moveEvent.clientY)
+                    )
                 }
 
                 const onEnter = () => {
@@ -624,12 +654,19 @@ window.addEventListener('DOMContentLoaded', () => {
                 }
 
                 if (isEncoder) {
-                    const interaction = startEncoderInteraction(touch.clientX)
+                    const interaction = startEncoderInteraction(
+                        getAxisValue(touch.clientX, touch.clientY)
+                    )
 
                     const onTouchMove = (moveEvent) => {
                         const moveTouch = moveEvent.touches[0]
                         if (moveTouch) {
-                            interaction.onMove(moveTouch.clientX)
+                            interaction.onMove(
+                                getAxisValue(
+                                    moveTouch.clientX,
+                                    moveTouch.clientY
+                                )
+                            )
                         }
                     }
 

--- a/src/ipcHandlers.ts
+++ b/src/ipcHandlers.ts
@@ -263,6 +263,10 @@ export function initializeIpcHandlers() {
                 `device.${deviceId}.key.${keyIndex}.isSticky`,
                 false
             ),
+            verticalEncoder: store.get(
+                `device.${deviceId}.key.${keyIndex}.verticalEncoder`,
+                false
+            ),
         }
     })
 
@@ -282,11 +286,19 @@ export function initializeIpcHandlers() {
                     `device.${deviceId}.key.${keyIndex}.isSticky`,
                     false
                 ),
+                verticalEncoder: store.get(
+                    `device.${deviceId}.key.${keyIndex}.verticalEncoder`,
+                    false
+                ),
             }
             const merged = { ...existing, ...config }
             store.set(`device.${deviceId}.key.${keyIndex}.isEncoder`, merged.isEncoder)
             store.set(`device.${deviceId}.key.${keyIndex}.stepSize`, merged.stepSize)
             store.set(`device.${deviceId}.key.${keyIndex}.isSticky`, merged.isSticky)
+            store.set(
+                `device.${deviceId}.key.${keyIndex}.verticalEncoder`,
+                merged.verticalEncoder
+            )
         }
     )
 


### PR DESCRIPTION
## Summary
- Implements issue #46: "It would be nice if an up/down motion of the cursor or touch on an encoder would send right/left to Companion."
- Design decisions (confirmed before starting): per-key toggle (consistent with the existing isEncoder/stepSize/isSticky per-key model), and vertical drag *replaces* horizontal drag for that key rather than both being simultaneously active.
- New per-key `verticalEncoder` boolean, same storage/IPC tier as the other per-key encoder settings (`getKeyConfig`/`updateKeyConfig` in `src/ipcHandlers.ts`).
- In `public/index.js`, added a small `getAxisValue(clientX, clientY)` helper that returns `-clientY` when vertical mode is on, otherwise `clientX` — since `startEncoderInteraction`/`handleDirection` only ever operate on an abstract 1D scalar, this was the only change needed at the 4 call sites (mouse drag start/move, touch start/move); no changes to the drag-threshold or rotation logic itself.
- Dragging up increases (rotateRight), dragging down decreases (rotateLeft), matching the "value going up or down" framing in the issue.
- New "Toggle Vertical/Horizontal Drag" context-menu item, following the same get-current-config-then-merge pattern as the existing "Set Step Size..."/"Clear Sticky Mode" items so it doesn't reset unrelated key config.
- The mouse wheel (which already rotates via `deltaY`) is untouched — this only affects click-and-drag / touch-drag.

## Test plan
- [x] `tsc` build passes
- [x] `index.js` syntax-checks clean
- [x] Live-launched against a real running Companion instance, no startup errors
- [x] Verified the real IPC round-trip via CDP `Runtime.evaluate` against the live renderer: `getKeyConfig`/`updateKeyConfig` correctly read/write/merge the new `verticalEncoder` field without disturbing `isEncoder`/`stepSize`/`isSticky`, then restored the test key to its original state afterward (confirmed via a final `getKeyConfig` read)
- [ ] Could not simulate an actual mouse-drag or touch-drag gesture from this environment (no input-injection tool) to visually confirm the encoder rotates in the expected direction — the axis-value math was traced by hand instead (drag up → negative clientY delta → negated to positive → same code path as an existing rightward horizontal drag). Worth a quick manual check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)