### PR TITLE
Add resizable device windows with live-scaling grid

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -38,6 +38,8 @@ window.addEventListener('DOMContentLoaded', () => {
     let globalAutoHideOnLeave = false
     let globalHideEmptyKeys = false
     let deviceDisplayName = deviceId
+    let globalBitmapSize = 72
+    let globalResizable = false
 
     // Request config from main process
     window.electronAPI.getDeviceConfig(deviceId).then((config) => {
@@ -48,6 +50,8 @@ window.addEventListener('DOMContentLoaded', () => {
             hideEmptyKeys,
             backgroundColor,
             backgroundOpacity,
+            bitmapSize,
+            resizable,
         } = config
 
         deviceDisplayName = name || deviceId
@@ -55,6 +59,8 @@ window.addEventListener('DOMContentLoaded', () => {
         configureDimOnLeave(globalDimOnLeave)
         globalAutoHideOnLeave = autoHide || false
         globalHideEmptyKeys = hideEmptyKeys || false
+        globalBitmapSize = bitmapSize || 72
+        globalResizable = resizable || false
 
         const keypad = document.getElementById('keypad')
         if (keypad) {
@@ -775,9 +781,16 @@ window.addEventListener('DOMContentLoaded', () => {
         )
     })
 
-    window.electronAPI.onRebuildGrid((_, { columnCount, rowCount }) => {
+    window.electronAPI.onRebuildGrid((_, { columnCount, rowCount, bitmapSize }) => {
         globalColumnCount = columnCount
+        if (bitmapSize) {
+            globalBitmapSize = bitmapSize
+        }
         buildKeyGrid(columnCount, rowCount)
+        // A rebuild means the window now natively matches globalBitmapSize
+        // again (whether from Settings or the resize-drag settle step
+        // below), so any in-progress CSS scale preview should be cleared.
+        resetResizeScalePreview()
     })
 
     // Handle key events from Companion
@@ -992,4 +1005,100 @@ window.addEventListener('DOMContentLoaded', () => {
             document.body.classList.remove('dimmed')
         }
     }
+
+    // --- Resizable window support (#13) ---
+    //
+    // Every key is forced to the same square bitmapSize, so dragging a
+    // resizable device window to a new size is equivalent to choosing a new
+    // bitmapSize - rather than building a second sizing model, this scales
+    // the grid visually with a CSS transform for smooth feedback *while*
+    // dragging, then - once the user stops - hands off to the exact same
+    // updateDeviceConfig reflow that Settings' "Bitmap" field already uses
+    // (which resizes the window to fit exactly, asks Companion to redraw
+    // crisp bitmaps at the new resolution, and rebuilds the grid).
+    //
+    // Mirrors calculateWindowSize() in src/device.ts - keep in sync if that
+    // formula ever changes.
+    function calculateNaturalSize(columnCount, rowCount, bitmapSize) {
+        const PADDING = 20
+        const GAP = 10
+        const width =
+            columnCount * bitmapSize + (columnCount - 1) * GAP + PADDING * 2
+        const height =
+            rowCount * bitmapSize + (rowCount - 1) * GAP + PADDING * 2
+        return { width, height }
+    }
+
+    let resizeSettleTimeout = null
+    // Set right before we trigger our own window resize (via
+    // updateDeviceConfig), so the resulting `resize` event doesn't
+    // re-trigger this whole scale/settle cycle on itself.
+    let ignoreNextResizeSettle = false
+
+    function resetResizeScalePreview() {
+        const keypad = document.getElementById('keypad')
+        if (keypad) {
+            keypad.style.transform = ''
+        }
+    }
+
+    function handleWindowResize() {
+        if (!globalResizable) return
+        if (ignoreNextResizeSettle) return
+
+        const keypad = document.getElementById('keypad')
+        if (!keypad || !globalColumnCount || !globalRowCount) return
+
+        const natural = calculateNaturalSize(
+            globalColumnCount,
+            globalRowCount,
+            globalBitmapSize
+        )
+        if (natural.width > 0) {
+            const scale = window.innerWidth / natural.width
+            keypad.style.transformOrigin = 'top left'
+            keypad.style.transform = `scale(${scale})`
+        }
+
+        clearTimeout(resizeSettleTimeout)
+        resizeSettleTimeout = setTimeout(settleResize, 400)
+    }
+
+    function settleResize() {
+        if (!globalResizable || !globalColumnCount || !globalRowCount) return
+
+        // Reverse of calculateNaturalSize()'s width formula
+        const PADDING = 20
+        const GAP = 10
+        const effectiveBitmapSize = Math.round(
+            (window.innerWidth - PADDING * 2 - (globalColumnCount - 1) * GAP) /
+                globalColumnCount
+        )
+
+        if (
+            !Number.isFinite(effectiveBitmapSize) ||
+            effectiveBitmapSize <= 0 ||
+            effectiveBitmapSize === globalBitmapSize
+        ) {
+            resetResizeScalePreview()
+            return
+        }
+
+        ignoreNextResizeSettle = true
+        window.electronAPI
+            .updateDeviceConfig({
+                deviceId,
+                config: { bitmapSize: effectiveBitmapSize },
+            })
+            .then(() => {
+                // onRebuildGrid (triggered by this same config change) clears
+                // the CSS preview once the window has been reflowed to its
+                // exact new native size.
+                setTimeout(() => {
+                    ignoreNextResizeSettle = false
+                }, 500)
+            })
+    }
+
+    window.addEventListener('resize', handleWindowResize)
 })

--- a/public/settings.js
+++ b/public/settings.js
@@ -87,6 +87,10 @@ window.addEventListener('DOMContentLoaded', () => {
                 device.alwaysOnTop
             )
             const movableInput = createCheckbox('Movable', device.movable)
+            const resizableInput = createCheckbox(
+                'Resizable',
+                device.resizable || false
+            )
             const disablePressInput = createCheckbox(
                 'Disable Button Presses',
                 device.disablePress
@@ -156,6 +160,7 @@ window.addEventListener('DOMContentLoaded', () => {
             ;[
                 alwaysOnTopInput,
                 movableInput,
+                resizableInput,
                 disablePressInput,
                 dimOnLeaveInput,
                 autoHideInput,
@@ -189,6 +194,7 @@ window.addEventListener('DOMContentLoaded', () => {
                     bitmapSize: parseInt(bitmapSizeInput.input.value),
                     alwaysOnTop: alwaysOnTopInput.input.checked,
                     movable: movableInput.input.checked,
+                    resizable: resizableInput.input.checked,
                     disablePress: disablePressInput.input.checked,
                     dimOnLeave: dimOnLeaveInput.input.checked,
                     autoHide: autoHideInput.input.checked,

--- a/src/device.ts
+++ b/src/device.ts
@@ -23,6 +23,7 @@ export function createDeviceWindow(deviceId: string) {
     const bitmapSize = store.get(`device.${deviceId}.bitmapSize`, 72)
     const alwaysOnTop = store.get(`device.${deviceId}.alwaysOnTop`, true)
     const movable = store.get(`device.${deviceId}.movable`, false)
+    const resizable = store.get(`device.${deviceId}.resizable`, false)
     const disablePress = store.get(`device.${deviceId}.disablePress`, false)
     const dimOnLeave = store.get(`device.${deviceId}.dimOnLeave`, false)
     const autoHide = store.get(`device.${deviceId}.autoHide`, false)
@@ -56,7 +57,7 @@ export function createDeviceWindow(deviceId: string) {
         transparent: true,
         frame: false,
         alwaysOnTop: alwaysOnTop,
-        resizable: false,
+        resizable: resizable,
         skipTaskbar: true,
         movable: movable,
         hasShadow: false,
@@ -73,6 +74,10 @@ export function createDeviceWindow(deviceId: string) {
     // On macOS, keep the overlay visible across all Spaces/desktops and over full-screen apps
     if (process.platform === 'darwin') {
         win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })
+    }
+
+    if (resizable) {
+        applyResizeConstraints(win, columnCount, rowCount)
     }
 
     win.loadFile(path.join(__dirname, '../public/index.html'), {
@@ -172,6 +177,7 @@ export function createNewDevice(): string {
     store.set(`device.${newDeviceId}.bitmapSize`, 72) // Default bitmap size
     store.set(`device.${newDeviceId}.alwaysOnTop`, true) // Default to true
     store.set(`device.${newDeviceId}.movable`, true) // Default to true
+    store.set(`device.${newDeviceId}.resizable`, false) // Default to false
     store.set(`device.${newDeviceId}.dimOnLeave`, false) // Default to false
     store.set(`device.${newDeviceId}.disablePress`, false) // Default to false
     store.set(`device.${newDeviceId}.backgroundColor`, '#000000') // Default black
@@ -203,6 +209,36 @@ export function calculateWindowSize(
         columnCount * KEY_WIDTH + (columnCount - 1) * GAP + PADDING * 2
     const height = rows * KEY_HEIGHT + (rows - 1) * GAP + PADDING * 2
     return { width, height }
+}
+
+// Bounds on the effective per-key bitmap size a resizable window is allowed
+// to be dragged to (issue #13) - keeps keys from shrinking to unusable
+// slivers or growing to unreasonably large squares.
+export const MIN_BITMAP_SIZE = 30
+export const MAX_BITMAP_SIZE = 200
+
+// Locks a resizable device window's aspect ratio to the key grid's
+// columns:rows so OS resize handles keep every key square, and clamps the
+// draggable size range to MIN_BITMAP_SIZE..MAX_BITMAP_SIZE per key (#13).
+export function applyResizeConstraints(
+    win: BrowserWindow,
+    columnCount: number,
+    rowCount: number
+) {
+    win.setAspectRatio(columnCount / rowCount)
+
+    const { width: minWidth, height: minHeight } = calculateWindowSize(
+        columnCount,
+        rowCount,
+        MIN_BITMAP_SIZE
+    )
+    const { width: maxWidth, height: maxHeight } = calculateWindowSize(
+        columnCount,
+        rowCount,
+        MAX_BITMAP_SIZE
+    )
+    win.setMinimumSize(minWidth, minHeight)
+    win.setMaximumSize(maxWidth, maxHeight)
 }
 
 //this is for the "hide empty keys" feature

--- a/src/ipcHandlers.ts
+++ b/src/ipcHandlers.ts
@@ -14,6 +14,7 @@ import {
     calculateWindowSize,
     showDeviceLabels,
     resizeWindowForDevice,
+    applyResizeConstraints,
 } from './device' // Import the device ID creation function
 import { store } from './store'
 
@@ -56,6 +57,18 @@ function applyDeviceConfig(deviceId: string, config: Record<string, any>) {
         if (config.movable !== undefined) {
             win.setMovable(Boolean(config.movable))
         }
+        if (config.resizable !== undefined) {
+            const isResizable = Boolean(config.resizable)
+            win.setResizable(isResizable)
+            if (isResizable) {
+                const columnCount = store.get(
+                    `device.${deviceId}.columnCount`,
+                    8
+                )
+                const rowCount = store.get(`device.${deviceId}.rowCount`, 4)
+                applyResizeConstraints(win, columnCount, rowCount)
+            }
+        }
         if (config.disablePress !== undefined) {
             win.webContents.send('disablePress', Boolean(config.disablePress))
         }
@@ -88,10 +101,19 @@ function applyDeviceConfig(deviceId: string, config: Record<string, any>) {
             // On Windows, BrowserWindow.setSize() can behave unreliably on
             // resizable: false windows, sometimes only applying one axis of
             // the resize (see #33). Temporarily allow resizing around the
-            // call as a workaround.
+            // call as a workaround, then restore the device's actual
+            // configured resizable state (not unconditionally false - #13
+            // added a real per-device resizable setting).
+            const isResizable = store.get(
+                `device.${deviceId}.resizable`,
+                false
+            ) as boolean
             win.setResizable(true)
             win.setSize(width, height)
-            win.setResizable(false)
+            win.setResizable(isResizable)
+            if (isResizable) {
+                applyResizeConstraints(win, columnCount, rowCount)
+            }
 
             // If the Satellite client is connected and key properties changed, update the device config
             if (global.satelliteClient) {
@@ -120,6 +142,7 @@ function applyDeviceConfig(deviceId: string, config: Record<string, any>) {
             win.webContents.send('rebuildGrid', {
                 columnCount,
                 rowCount,
+                bitmapSize,
             })
         }
 
@@ -162,6 +185,7 @@ export function initializeIpcHandlers() {
         const bitmapSize = store.get(`device.${deviceId}.bitmapSize`, 72)
         const alwaysOnTop = store.get(`device.${deviceId}.alwaysOnTop`, false)
         const movable = store.get(`device.${deviceId}.movable`, true)
+        const resizable = store.get(`device.${deviceId}.resizable`, false)
         const disablePress = store.get(`device.${deviceId}.disablePress`, false)
         const dimOnLeave = store.get(`device.${deviceId}.dimOnLeave`, false)
         const autoHide = store.get(`device.${deviceId}.autoHide`, false)
@@ -185,6 +209,7 @@ export function initializeIpcHandlers() {
             bitmapSize,
             alwaysOnTop,
             movable,
+            resizable,
             disablePress,
             dimOnLeave,
             autoHide,
@@ -479,6 +504,7 @@ export function initializeIpcHandlers() {
             bitmapSize: store.get(`device.${id}.bitmapSize`, 72),
             alwaysOnTop: store.get(`device.${id}.alwaysOnTop`, false),
             movable: store.get(`device.${id}.movable`, true),
+            resizable: store.get(`device.${id}.resizable`, false),
             disablePress: store.get(`device.${id}.disablePress`, false),
             dimOnLeave: store.get(`device.${id}.dimOnLeave`, false),
             autoHide: store.get(`device.${id}.autoHide`, false),
@@ -503,6 +529,7 @@ export function initializeIpcHandlers() {
             bitmapSize: 72,
             alwaysOnTop: true,
             movable: true,
+            resizable: false,
             disablePress: false,
             dimOnLeave: false,
             backgroundColor: '#000000',


### PR DESCRIPTION
## Summary
- Implements issue #13: "Adding ability to resize window and adjust fonts/bitmaps as required to better place on screen."
- Design (see approved plan): a new per-device `resizable` toggle (default off, matching the existing `movable` model). Since every key in a device is forced to one square `bitmapSize`, dragging a resizable window to a new size is treated as equivalent to picking a new `bitmapSize` — this reuses the *existing*, already-proven `updateDeviceConfig`/`applyDeviceConfig` reflow pipeline (the same one the Settings "Bitmap" field and "Reset to Defaults" already use) rather than building a second sizing model.
- `src/device.ts`: `createDeviceWindow` sets `resizable: true` when enabled, locks the aspect ratio via `win.setAspectRatio(columnCount / rowCount)` so OS resize handles keep keys square automatically, and clamps the draggable range via `setMinimumSize`/`setMaximumSize` computed from the existing `calculateWindowSize()` at a 30–200px per-key bound.
- `src/ipcHandlers.ts`: `applyDeviceConfig` re-applies the aspect ratio/bounds whenever `resizable` is toggled on or `columnCount`/`rowCount` change. **Also fixes a real bug this change would otherwise reintroduce**: the existing #33 workaround (`setResizable(true)` → `setSize()` → `setResizable(false)`) unconditionally hardcoded the window back to non-resizable after every size-relevant config change — it now restores the device's actual configured `resizable` state instead.
- `public/index.js`: a `window.resize` listener applies `#keypad { transform: scale(...) }` for instant visual feedback while dragging (this covers "adjust fonts" for free — text renders crisply at any CSS scale, unlike raster bitmaps, so no separate font-scaling code was needed). Debounced 400ms after the drag stops, it computes the effective new `bitmapSize` and calls the existing `updateDeviceConfig` reflow, which resizes the window to fit exactly, asks Companion to redraw crisp bitmaps at the new resolution, and rebuilds the grid — clearing the temporary CSS scale once that lands. A guard flag prevents this from re-triggering on the resize event its own reflow causes.
- New "Resizable" checkbox in Settings, alongside "Movable".

## Test plan
- [x] `tsc` build passes; both renderer JS files syntax-check clean
- [x] Full `electronAPI` cross-check against `preload.ts` — no new methods needed, and no leftover generic calls
- [x] Live-launched against a real Companion connection, then used CDP `Runtime.evaluate` against the live renderer to exercise the real pipeline end-to-end:
  - Enabling `resizable` via `updateDeviceConfig` round-trips correctly with no thrown exception (confirms `setAspectRatio`/`setMinimumSize`/`setMaximumSize` execute cleanly)
  - Simulated the "settle" step (`updateDeviceConfig({bitmapSize: 60})`) with `resizable: true` active — window correctly resized to the exact expected pixel dimensions for that grid, `resizable` stayed `true` afterward (confirming the #33-workaround fix works), the grid's `gridTemplateColumns` reflowed to the new 60px size, and the CSS scale transform was correctly reset to empty
  - Restored the test device to its exact original state (`resizable: false`, `bitmapSize: 50`) afterward and confirmed via the real config file on disk
- [ ] **Real limitation, stated upfront**: I have no way to simulate an actual mouse drag on a window's OS-level resize handle from this environment (no input-injection tool), so the live CSS-scale-during-drag feedback and the OS-level aspect-ratio-locked resize behavior itself couldn't be interactively verified — only reasoned through and confirmed not to throw errors via the settle-step simulation above. This is worth a manual drag-test before merging more than any other feature this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)