### PR TITLE
Add collapsible device windows (double-click drag handle)

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -824,6 +824,14 @@ window.addEventListener('DOMContentLoaded', () => {
         window.electronAPI.closeKeypad(deviceId) // Send deviceId so main process knows which to close
     })
 
+    // Double-click the drag handle to collapse/expand the window (#40)
+    const dragHandle = document.getElementById('dragHandle')
+    if (dragHandle) {
+        dragHandle.addEventListener('dblclick', () => {
+            window.electronAPI.toggleDeviceCollapsed(deviceId)
+        })
+    }
+
     function processKey(keyObj) {
         console.log('Processing key:', keyObj)
 

--- a/src/device.ts
+++ b/src/device.ts
@@ -24,6 +24,7 @@ export function createDeviceWindow(deviceId: string) {
     const alwaysOnTop = store.get(`device.${deviceId}.alwaysOnTop`, true)
     const movable = store.get(`device.${deviceId}.movable`, false)
     const resizable = store.get(`device.${deviceId}.resizable`, false)
+    const collapsed = store.get(`device.${deviceId}.collapsed`, false)
     const disablePress = store.get(`device.${deviceId}.disablePress`, false)
     const dimOnLeave = store.get(`device.${deviceId}.dimOnLeave`, false)
     const autoHide = store.get(`device.${deviceId}.autoHide`, false)
@@ -51,13 +52,18 @@ export function createDeviceWindow(deviceId: string) {
 
     const win = new BrowserWindow({
         width: width,
-        height: height,
+        // If this device was collapsed when the app last quit, launch
+        // already collapsed instead of flashing full-size first (#40).
+        height: collapsed ? COLLAPSED_HEIGHT : height,
         x: x,
         y: y,
         transparent: true,
         frame: false,
         alwaysOnTop: alwaysOnTop,
-        resizable: resizable,
+        // Resizing and collapsing fight each other (aspect-ratio lock vs. a
+        // tiny fixed collapsed height), so a collapsed window is never
+        // resizable - toggleDeviceCollapsed() restores this on expand.
+        resizable: resizable && !collapsed,
         skipTaskbar: true,
         movable: movable,
         hasShadow: false,
@@ -76,7 +82,7 @@ export function createDeviceWindow(deviceId: string) {
         win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })
     }
 
-    if (resizable) {
+    if (resizable && !collapsed) {
         applyResizeConstraints(win, columnCount, rowCount)
     }
 
@@ -216,6 +222,10 @@ export function calculateWindowSize(
 // slivers or growing to unreasonably large squares.
 export const MIN_BITMAP_SIZE = 30
 export const MAX_BITMAP_SIZE = 200
+
+// Window height when a device is collapsed (issue #40) - just tall enough
+// to show the drag handle strip so it stays grabbable/double-clickable.
+export const COLLAPSED_HEIGHT = 36
 
 // Locks a resizable device window's aspect ratio to the key grid's
 // columns:rows so OS resize handles keep every key square, and clamps the

--- a/src/ipcHandlers.ts
+++ b/src/ipcHandlers.ts
@@ -15,6 +15,7 @@ import {
     showDeviceLabels,
     resizeWindowForDevice,
     applyResizeConstraints,
+    COLLAPSED_HEIGHT,
 } from './device' // Import the device ID creation function
 import { store } from './store'
 
@@ -541,6 +542,50 @@ export function initializeIpcHandlers() {
         console.log(`Device ${deviceId} reset to defaults.`)
 
         return defaultConfig
+    })
+
+    // Double-click the drag handle collapses a device down to just its top
+    // strip, or restores it back to its full grid size (issue #40). Mutually
+    // exclusive with resizing (#13): while collapsed, resizing is disabled
+    // and the aspect-ratio lock is released, both restored on expand.
+    ipcMain.handle('toggleDeviceCollapsed', (_event, deviceId) => {
+        const win = global.deviceWindows.get(deviceId)
+        if (!win) return false
+
+        const collapsed = !store.get(`device.${deviceId}.collapsed`, false)
+        store.set(`device.${deviceId}.collapsed`, collapsed)
+
+        const { x, y, width } = win.getBounds()
+        const resizable = store.get(
+            `device.${deviceId}.resizable`,
+            false
+        ) as boolean
+
+        if (collapsed) {
+            if (resizable) {
+                win.setAspectRatio(0)
+            }
+            win.setResizable(false)
+            win.setBounds({ x, y, width, height: COLLAPSED_HEIGHT })
+        } else {
+            const columnCount = store.get(`device.${deviceId}.columnCount`, 8)
+            const rowCount = store.get(`device.${deviceId}.rowCount`, 4)
+            const bitmapSize = store.get(`device.${deviceId}.bitmapSize`, 72)
+            const { height } = calculateWindowSize(
+                columnCount,
+                rowCount,
+                bitmapSize
+            )
+
+            win.setBounds({ x, y, width, height })
+
+            if (resizable) {
+                win.setResizable(true)
+                applyResizeConstraints(win, columnCount, rowCount)
+            }
+        }
+
+        return collapsed
     })
 
     ipcMain.handle('deleteDevice', (_event, deviceId) => {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -86,6 +86,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     resetDeviceToDefaults: (deviceId: string) =>
         ipcRenderer.invoke('resetDeviceToDefaults', deviceId),
 
+    // Collapse/expand a device window (double-click its drag handle)
+    toggleDeviceCollapsed: (deviceId: string) =>
+        ipcRenderer.invoke('toggleDeviceCollapsed', deviceId),
+
     // Get the current window bounds for a device's keypad window
     getKeypadBounds: (deviceId: string) =>
         ipcRenderer.invoke('getKeypadBounds', deviceId),


### PR DESCRIPTION
## Summary
- Implements issue #40: collapse a deck down to just a thin bar instead of fully closing it (Mac-Stickies-style, per the issue's own reference).
- **Note: base branch is `feat/resizable-window` (#80), not `main`** — this feature needs to coordinate with issue #13's resizable/aspect-ratio-lock logic (both fight over the window's height), so it's stacked on that PR rather than main. Once #80 merges, GitHub will automatically retarget this PR's base to `main`.
- Scope confirmed with the user before building: **manual double-click toggle only** (no hover/auto-reveal — kept distinct from issue #10, planned separately), and **always collapses to the top** (height-only shrink, x/y/width unchanged) rather than anchoring to the nearest screen edge.
- Double-clicking the existing `#dragHandle` element (added for #37) calls a new `toggleDeviceCollapsed` IPC handler in `src/ipcHandlers.ts`, which flips a `device.<id>.collapsed` store flag and resizes the window via `setBounds` — shrinking to a fixed `COLLAPSED_HEIGHT` (36px) or restoring via the existing `calculateWindowSize()`.
- Mutually exclusive with #13's resizable feature: collapsing temporarily disables resizing and releases the aspect-ratio lock (`setAspectRatio(0)`), both restored via the existing `applyResizeConstraints()` helper on expand.
- A collapsed device now launches already-collapsed on the next app start (`src/device.ts`), instead of briefly flashing full-size first.
- No Settings UI toggle — like moving a window, this is meant as a quick in-context interaction, not a configured mode (though the state does persist across restarts).

## Test plan
- [x] `tsc` build passes, `index.js` syntax-checks clean, full `electronAPI` cross-check against `preload.ts` (no leftover generic calls)
- [x] Live-launched against a real Companion connection; used CDP `Runtime.evaluate` against the live renderer to call `toggleDeviceCollapsed` directly:
  - Window went from 510×270 → exactly 510×36 on collapse, and back to exactly 510×270 on expand (x/y confirmed unchanged)
  - No exceptions in either direction
  - Also tested the #13 interaction: enabled `resizable`, collapsed, expanded — no exceptions, `resizable` state correctly preserved end-to-end
  - Restored the test device to its exact original state afterward, confirmed via the real config file
- [ ] **Real limitation, stated upfront**: I can't simulate an actual double-click gesture from this environment, and can't visually confirm the collapsed strip looks acceptable (whether the close button/device label overlap or look off at 36px height) — the underlying IPC/resize mechanics are verified directly, but the interaction trigger itself and visual polish are worth a manual check before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)