### PR TITLE
Add edge-reveal: show a hidden device near its screen corner (#10)

### DIFF
--- a/public/settings.js
+++ b/public/settings.js
@@ -99,6 +99,10 @@ window.addEventListener('DOMContentLoaded', () => {
                 'Auto Hide on Mouse Leave',
                 device.autoHide || false
             )
+            const edgeRevealInput = createCheckbox(
+                'Edge Reveal (show near its screen corner)',
+                device.edgeReveal || false
+            )
             const hideEmptyKeysInput = createCheckbox(
                 'Hide Empty Keys',
                 device.hideEmptyKeys || false
@@ -159,6 +163,7 @@ window.addEventListener('DOMContentLoaded', () => {
                 disablePressInput,
                 dimOnLeaveInput,
                 autoHideInput,
+                edgeRevealInput,
                 hideEmptyKeysInput,
             ].forEach((inputObj) => {
                 rightFields.appendChild(inputObj.label)
@@ -192,6 +197,7 @@ window.addEventListener('DOMContentLoaded', () => {
                     disablePress: disablePressInput.input.checked,
                     dimOnLeave: dimOnLeaveInput.input.checked,
                     autoHide: autoHideInput.input.checked,
+                    edgeReveal: edgeRevealInput.input.checked,
                     hideEmptyKeys: hideEmptyKeysInput.input.checked,
                     backgroundColor: backgroundColorInput.value,
                     backgroundOpacity: parseFloat(backgroundOpacityInput.value),

--- a/src/device.ts
+++ b/src/device.ts
@@ -144,7 +144,15 @@ export function showWindows(ignoreHiddenState = false) {
     global.deviceWindows.forEach((win, deviceId) => {
         console.log(`Showing window for deviceId: ${deviceId}`)
         const hidden = store.get(`device.${deviceId}.hidden`, false)
+        const edgeReveal = store.get(`device.${deviceId}.edgeReveal`, false)
         if (ignoreHiddenState || !hidden) {
+            // An edgeReveal device isn't force-shown here (#10) - it starts
+            // hidden and the poll loop in startEdgeRevealPolling() reveals
+            // it when the cursor nears its corner instead.
+            if (edgeReveal) {
+                win.hide()
+                return
+            }
             win.show()
             win.focus()
             win.webContents.send('windowShown', { deviceId })
@@ -173,6 +181,7 @@ export function createNewDevice(): string {
     store.set(`device.${newDeviceId}.alwaysOnTop`, true) // Default to true
     store.set(`device.${newDeviceId}.movable`, true) // Default to true
     store.set(`device.${newDeviceId}.dimOnLeave`, false) // Default to false
+    store.set(`device.${newDeviceId}.edgeReveal`, false) // Default to false
     store.set(`device.${newDeviceId}.disablePress`, false) // Default to false
     store.set(`device.${newDeviceId}.backgroundColor`, '#000000') // Default black
     store.set(`device.${newDeviceId}.backgroundOpacity`, 0.5) // Default semi-transparent
@@ -279,4 +288,114 @@ export function resizeWindowForDevice(deviceId: string) {
         y: win.getBounds().y,
     })
     win.setResizable(false)
+}
+
+// --- Edge-reveal support (#10) ---
+//
+// A device with `edgeReveal` enabled stays hidden until the cursor
+// approaches whichever screen corner its window is closest to, then shows
+// without stealing focus and hides again a short delay after the cursor
+// moves away from both the corner and the window itself.
+
+const EDGE_REVEAL_POLL_INTERVAL = 150 // ms between cursor checks
+const EDGE_REVEAL_ZONE_SIZE = 40 // px from the exact screen corner
+const EDGE_REVEAL_HIDE_DELAY = 500 // ms cursor must be away before hiding
+
+const edgeRevealHideTimers = new Map<string, NodeJS.Timeout>()
+
+interface ScreenPoint {
+    x: number
+    y: number
+}
+
+interface ScreenRect {
+    x: number
+    y: number
+    width: number
+    height: number
+}
+
+// Whichever corner of `workArea` the window's center is closest to.
+function getNearestCorner(
+    windowBounds: ScreenRect,
+    workArea: ScreenRect
+): ScreenPoint {
+    const centerX = windowBounds.x + windowBounds.width / 2
+    const centerY = windowBounds.y + windowBounds.height / 2
+    const isLeft = centerX < workArea.x + workArea.width / 2
+    const isTop = centerY < workArea.y + workArea.height / 2
+
+    return {
+        x: isLeft ? workArea.x : workArea.x + workArea.width,
+        y: isTop ? workArea.y : workArea.y + workArea.height,
+    }
+}
+
+function isPointNearCorner(
+    point: ScreenPoint,
+    corner: ScreenPoint,
+    zoneSize: number
+): boolean {
+    return (
+        Math.abs(point.x - corner.x) <= zoneSize &&
+        Math.abs(point.y - corner.y) <= zoneSize
+    )
+}
+
+function isPointInBounds(point: ScreenPoint, bounds: ScreenRect): boolean {
+    return (
+        point.x >= bounds.x &&
+        point.x <= bounds.x + bounds.width &&
+        point.y >= bounds.y &&
+        point.y <= bounds.y + bounds.height
+    )
+}
+
+// Starts a single persistent poll loop covering every device window, rather
+// than one timer per device - cheap no-op for devices without edgeReveal
+// enabled. Call once at app startup.
+export function startEdgeRevealPolling() {
+    setInterval(() => {
+        const cursor = screen.getCursorScreenPoint()
+
+        global.deviceWindows.forEach((win, deviceId) => {
+            const edgeReveal = store.get(`device.${deviceId}.edgeReveal`, false)
+            if (!edgeReveal) return
+
+            // Manually hidden via the tray/close button takes precedence -
+            // edgeReveal doesn't reveal a device the user explicitly hid.
+            const hidden = store.get(`device.${deviceId}.hidden`, false)
+            if (hidden) return
+
+            const windowBounds = win.getBounds()
+            const display = screen.getDisplayNearestPoint({
+                x: windowBounds.x,
+                y: windowBounds.y,
+            })
+            const corner = getNearestCorner(windowBounds, display.workArea)
+            const nearCorner = isPointNearCorner(
+                cursor,
+                corner,
+                EDGE_REVEAL_ZONE_SIZE
+            )
+            const overWindow = isPointInBounds(cursor, windowBounds)
+
+            if (nearCorner || overWindow) {
+                const existingTimer = edgeRevealHideTimers.get(deviceId)
+                if (existingTimer) {
+                    clearTimeout(existingTimer)
+                    edgeRevealHideTimers.delete(deviceId)
+                }
+                if (!win.isVisible()) {
+                    win.showInactive()
+                }
+            } else if (win.isVisible() && !edgeRevealHideTimers.has(deviceId)) {
+                const timer = setTimeout(() => {
+                    win.hide()
+                    edgeRevealHideTimers.delete(deviceId)
+                }, EDGE_REVEAL_HIDE_DELAY)
+                edgeRevealHideTimers.set(deviceId, timer)
+            }
+        })
+    }, EDGE_REVEAL_POLL_INTERVAL)
 }

--- a/src/ipcHandlers.ts
+++ b/src/ipcHandlers.ts
@@ -59,6 +59,17 @@ function applyDeviceConfig(deviceId: string, config: Record<string, any>) {
         if (config.disablePress !== undefined) {
             win.webContents.send('disablePress', Boolean(config.disablePress))
         }
+        if (config.edgeReveal !== undefined) {
+            // Turning edgeReveal on hands visibility control to the poll
+            // loop (startEdgeRevealPolling), so hide immediately rather than
+            // waiting for the cursor to move; turning it off falls back to
+            // being purely `hidden`-controlled, so show immediately (#10).
+            if (Boolean(config.edgeReveal)) {
+                win.hide()
+            } else {
+                win.show()
+            }
+        }
         if (config.dimOnLeave !== undefined) {
             win.webContents.send('dimOnLeave', Boolean(config.dimOnLeave))
         }
@@ -148,7 +159,12 @@ function applyDeviceConfig(deviceId: string, config: Record<string, any>) {
             })
         }
 
-        win.show()
+        // Skip the usual "make sure it's visible" show() if we just
+        // intentionally hid this window to hand control to the edgeReveal
+        // poll loop (#10) - otherwise this would immediately undo that.
+        if (!(config.edgeReveal !== undefined && Boolean(config.edgeReveal))) {
+            win.show()
+        }
     }
 
     updateTrayMenu()
@@ -165,6 +181,7 @@ export function initializeIpcHandlers() {
         const disablePress = store.get(`device.${deviceId}.disablePress`, false)
         const dimOnLeave = store.get(`device.${deviceId}.dimOnLeave`, false)
         const autoHide = store.get(`device.${deviceId}.autoHide`, false)
+        const edgeReveal = store.get(`device.${deviceId}.edgeReveal`, false)
         const hideEmptyKeys = store.get(
             `device.${deviceId}.hideEmptyKeys`,
             false
@@ -188,6 +205,7 @@ export function initializeIpcHandlers() {
             disablePress,
             dimOnLeave,
             autoHide,
+            edgeReveal,
             hideEmptyKeys,
             backgroundColor,
             backgroundOpacity,
@@ -482,6 +500,7 @@ export function initializeIpcHandlers() {
             disablePress: store.get(`device.${id}.disablePress`, false),
             dimOnLeave: store.get(`device.${id}.dimOnLeave`, false),
             autoHide: store.get(`device.${id}.autoHide`, false),
+            edgeReveal: store.get(`device.${id}.edgeReveal`, false),
             hideEmptyKeys: store.get(`device.${id}.hideEmptyKeys`, false),
             backgroundColor: store.get(
                 `device.${id}.backgroundColor`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import createTray from './tray' // Import the tray creation function
 
 import { initializeDeviceIds, createSatellite } from './utils' // Import utility functions
 
-import { createDeviceWindows } from './device' // Import device window creation
+import { createDeviceWindows, startEdgeRevealPolling } from './device' // Import device window creation
 
 import { loadHotkeysFromStore } from './hotkeys'
 
@@ -64,6 +64,7 @@ function init() {
     createDeviceWindows() // Create device windows
     createSatellite() // Initialize the Companion Satellite client
     loadHotkeysFromStore() // Load hotkeys from the store
+    startEdgeRevealPolling() // Start polling cursor position for edge-reveal devices (#10)
 }
 
 app.whenReady().then(() => {


### PR DESCRIPTION
## Summary
- Adds a new per-device **Edge Reveal** toggle (Settings > device), separate from the existing `hidden` flag used by the tray Show/Hide menu, so toggling one doesn't surprise the other.
- When enabled, the device window stays hidden until the cursor approaches whichever screen corner its window sits closest to (auto-inferred from its saved position — no extra configuration needed), then reveals via `win.showInactive()` (doesn't steal focus), and hides again after a short debounced delay once the cursor leaves both the corner zone and the window itself.
- Implemented as a single persistent poll loop (`startEdgeRevealPolling`, ~150ms interval, started once from `main.ts`'s `init()`) rather than one timer per device, since Electron doesn't deliver mouse-move events outside its own windows.
- `showWindows()` no longer force-shows an edge-reveal-enabled, not-manually-hidden device at startup/satellite-connect — it starts hidden and the poll loop takes over from there. Explicit tray Show/Hide actions are untouched and still work immediately regardless of `edgeReveal`.
- Also fixes a real bug this surfaced: `applyDeviceConfig` had an unconditional trailing `win.show()` that would have immediately undone the "hide when edgeReveal turns on" behavior — it now skips that call when `edgeReveal` is being turned on.

Fixes #10

## Test plan
- [x] `tsc` build clean
- [x] JS syntax check (`node -c`) on modified `public/*.js` clean
- [x] `electronAPI` vs `preload.ts` cross-check clean (no orphaned calls)
- [x] Live CDP verification against a real running Companion Satellite server: `updateDeviceConfig({edgeReveal:true})` immediately hides the window; `{edgeReveal:false}` immediately re-shows it; no exceptions thrown
- [x] Corner-detection math (nearest-corner inference, proximity-zone check) verified via a standalone script with 6 hand-checked test cases, all passing
- [ ] Actual "wave the cursor into a screen corner and watch it reveal" experience on a real multi-monitor desktop — this environment has no way to simulate physical cursor movement or a real multi-monitor layout, so this needs a manual check before merging