### PR TITLE
Add mDNS discovery + remote configuration (#4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
         "generateUpdatesFilesForAllChannels": false
     },
     "dependencies": {
+        "@julusian/bonjour-service": "^1.4.3",
         "electron-store": "^8.0.0",
         "semver": "^7.7.2",
         "short-uuid": "^5.2.0",

--- a/public/settings.html
+++ b/public/settings.html
@@ -85,6 +85,39 @@
             </label>
             <br />
 
+            <h2>Discovery &amp; Remote Configuration</h2>
+            <label for="installationName">Installation Name:</label>
+            <input
+                type="text"
+                id="installationName"
+                placeholder="ScreenDeck"
+                style="width: 200px"
+            />
+            <br />
+            <label for="mdnsEnabled">
+                <input type="checkbox" id="mdnsEnabled" />
+                Enable mDNS Discovery (let Companion find this ScreenDeck on
+                the network)
+            </label>
+            <br />
+            <label for="restEnabled">
+                <input type="checkbox" id="restEnabled" />
+                Enable Remote Configuration (REST API)
+            </label>
+            <label for="restPort">Port:</label>
+            <input
+                type="number"
+                id="restPort"
+                placeholder="9999"
+                style="width: 60px"
+            />
+            <p style="font-size: 12px; opacity: 0.7; max-width: 500px">
+                When enabled, other devices on your network can view this
+                ScreenDeck's connection status and change which Companion
+                server it connects to. This API is not password protected,
+                so only enable it on a trusted network.
+            </p>
+
             <button id="saveCompanion" style="width: 80x">Save</button>
             <span
                 id="saveStatus"

--- a/public/settings.js
+++ b/public/settings.js
@@ -25,10 +25,23 @@ window.addEventListener('DOMContentLoaded', () => {
             const showOnStartup =
                 document.getElementById('showOnStartup').checked
 
+            const installationName =
+                document.getElementById('installationName').value
+            const mdnsEnabled = document.getElementById('mdnsEnabled').checked
+            const restEnabled = document.getElementById('restEnabled').checked
+            const restPort = parseInt(
+                document.getElementById('restPort').value,
+                10
+            )
+
             await window.electronAPI.saveSettings({
                 companionIP: ip,
                 companionPort: port,
                 showOnStartup: showOnStartup,
+                installationName: installationName,
+                mdnsEnabled: mdnsEnabled,
+                restEnabled: restEnabled,
+                restPort: restPort,
             })
 
             // Show status message
@@ -55,6 +68,15 @@ window.addEventListener('DOMContentLoaded', () => {
             settings.companionPort || 16622
         document.getElementById('showOnStartup').checked =
             settings.showOnStartup !== false
+
+        document.getElementById('installationName').value =
+            settings.installationName || ''
+        document.getElementById('mdnsEnabled').checked =
+            settings.mdnsEnabled !== false
+        document.getElementById('restEnabled').checked =
+            settings.restEnabled !== false
+        document.getElementById('restPort').value =
+            settings.restPort || 9999
     }
 
     async function loadDevices() {

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,10 +1,16 @@
 // src/defaults.ts
 
+import os from 'os'
+
 export const defaultSettings = {
     companionIP: '127.0.0.1',
     companionPort: 16622,
     showOnStartup: true,
     deviceIds: [],
+    installationName: `ScreenDeck ${os.hostname()}`,
+    mdnsEnabled: true,
+    restEnabled: true,
+    restPort: 9999,
 }
 
 export type SettingsType = typeof defaultSettings

--- a/src/ipcHandlers.ts
+++ b/src/ipcHandlers.ts
@@ -1,6 +1,6 @@
 import { ipcMain, BrowserWindow } from 'electron'
 import * as path from 'path'
-import { createSatellite, getNextProfileName } from './utils'
+import { getNextProfileName, applyCompanionConnectionSettings } from './utils'
 import { updateTrayMenu } from './tray'
 
 import {
@@ -673,29 +673,7 @@ export function initializeIpcHandlers() {
 
     // Handle saving settings
     ipcMain.handle('saveSettings', (_event, newSettings) => {
-        const previousIP = store.get('companionIP', '127.0.0.1')
-        const previousPort = store.get('companionPort', 16622)
-
-        store.set(newSettings)
-
-        const newIP = newSettings.companionIP
-        const newPort = newSettings.companionPort
-
-        if (newIP !== previousIP || newPort !== previousPort) {
-            console.log(
-                'Companion IP or port changed, restarting connection...'
-            )
-
-            if (global.satelliteClient) {
-                global.satelliteClient.disconnect() // Your close method for the new API
-                global.satelliteClient = null
-            }
-
-            // Wait briefly, then reconnect with the new IP/port
-            setTimeout(() => {
-                createSatellite() // Your function to initialize the Satellite client
-            }, 500)
-        }
+        applyCompanionConnectionSettings(newSettings)
     })
 
     ipcMain.handle('closeSettingsWindow', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,9 @@ import { createDeviceWindows, startEdgeRevealPolling } from './device' // Import
 
 import { loadHotkeysFromStore, HotkeyBinding } from './hotkeys'
 
+import { startRestServer, watchRestServerSettings } from './restServer'
+import { startMdnsAnnouncer, watchMdnsAnnouncerSettings } from './mdnsAnnouncer'
+
 declare global {
     var satelliteClient: CompanionSatelliteClient | null
     var deviceWindows: Map<string, BrowserWindow>
@@ -58,6 +61,11 @@ function init() {
     createSatellite() // Initialize the Companion Satellite client
     loadHotkeysFromStore() // Load hotkeys from the store
     startEdgeRevealPolling() // Start polling cursor position for edge-reveal devices (#10)
+
+    startRestServer() // Start the remote-config REST server (#4)
+    watchRestServerSettings()
+    startMdnsAnnouncer() // Advertise this install over mDNS (#4)
+    watchMdnsAnnouncerSettings()
 }
 
 app.whenReady().then(() => {

--- a/src/mdnsAnnouncer.ts
+++ b/src/mdnsAnnouncer.ts
@@ -1,0 +1,63 @@
+import { Bonjour, Service } from '@julusian/bonjour-service'
+import { store } from './store'
+
+// Advertises this ScreenDeck install over mDNS so it shows up in Companion's
+// Surfaces > Outbound "Discover" UI (#4). Mirrors bitfocus/companion-satellite's
+// own mdnsAnnouncer.ts (same service type/shape) so Companion's existing
+// discovery code recognizes it without any changes on Companion's side.
+
+const bonjour = new Bonjour()
+let service: Service | null = null
+
+export function startMdnsAnnouncer() {
+    if (!store.get('mdnsEnabled', true)) return
+    if (service) return
+
+    try {
+        const installationName = store.get(
+            'installationName',
+            'ScreenDeck'
+        ) as string
+        const restPort = store.get('restPort', 9999) as number
+        const restEnabled = store.get('restEnabled', true) as boolean
+
+        service = bonjour.publish(
+            {
+                name: installationName,
+                type: 'companion-satellite',
+                protocol: 'tcp',
+                port: restPort,
+                txt: { restEnabled },
+                ttl: 150,
+            },
+            {
+                announceOnInterval: 60 * 1000,
+            }
+        )
+    } catch (e) {
+        console.error('[MdnsAnnouncer] Failed to publish mdns service', e)
+    }
+}
+
+export function stopMdnsAnnouncer() {
+    if (service) {
+        service.stop?.()
+        service = null
+    }
+}
+
+let restartTimer: NodeJS.Timeout | undefined
+function debouncedRestart() {
+    if (restartTimer) clearTimeout(restartTimer)
+    restartTimer = setTimeout(() => {
+        stopMdnsAnnouncer()
+        startMdnsAnnouncer()
+    }, 50)
+}
+
+export function watchMdnsAnnouncerSettings() {
+    store.onDidChange('mdnsEnabled', debouncedRestart)
+    store.onDidChange('installationName', debouncedRestart)
+    store.onDidChange('restPort', debouncedRestart)
+    store.onDidChange('restEnabled', debouncedRestart)
+}

--- a/src/restServer.ts
+++ b/src/restServer.ts
@@ -1,0 +1,152 @@
+import http, { Server } from 'http'
+import { store } from './store'
+import { applyCompanionConnectionSettings } from './utils'
+
+// Minimal REST config server, matching the subset of bitfocus/companion-satellite's
+// own configuration API (see its openapi.yaml) that Companion's Surfaces > Outbound
+// "Discover" UI needs to show status and push a new Companion address (#4). No
+// authentication, same tradeoff the reference app makes - it's opt-in via Settings
+// and disclosed in this feature's PR description.
+
+let server: Server | null = null
+
+function sendJson(res: http.ServerResponse, status: number, body: unknown) {
+    const data = JSON.stringify(body)
+    res.writeHead(status, {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(data),
+    })
+    res.end(data)
+}
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+    return new Promise((resolve, reject) => {
+        let data = ''
+        req.on('data', (chunk) => {
+            data += chunk
+            // Guard against unbounded bodies from a misbehaving/malicious client
+            if (data.length > 1_000_000) {
+                req.destroy()
+                reject(new Error('Request body too large'))
+            }
+        })
+        req.on('end', () => resolve(data))
+        req.on('error', reject)
+    })
+}
+
+function getConfig() {
+    return {
+        protocol: 'tcp' as const,
+        host: store.get('companionIP', '127.0.0.1') as string,
+        port: store.get('companionPort', 16622) as number,
+        wsAddress: '',
+        installationName: store.get('installationName', '') as string,
+        mdnsEnabled: store.get('mdnsEnabled', true) as boolean,
+        httpEnabled: store.get('restEnabled', true) as boolean,
+        httpPort: store.get('restPort', 9999) as number,
+    }
+}
+
+async function handleRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+) {
+    const url = req.url ?? '/'
+
+    if (req.method === 'GET' && url === '/status') {
+        const client = global.satelliteClient
+        sendJson(res, 200, {
+            connected: client?.connected ?? false,
+            companionVersion: client?.companionVersion ?? null,
+            companionApiVersion: client?.companionApiVersion ?? null,
+            companionUnsupportedApi: client?.companionUnsupported ?? false,
+        })
+        return
+    }
+
+    if (req.method === 'GET' && url === '/config') {
+        sendJson(res, 200, getConfig())
+        return
+    }
+
+    if (req.method === 'POST' && url === '/config') {
+        let body: Record<string, unknown>
+        try {
+            const raw = await readBody(req)
+            body = raw ? JSON.parse(raw) : {}
+        } catch (e) {
+            sendJson(res, 400, { error: 'Invalid JSON body' })
+            return
+        }
+
+        if (body.protocol !== undefined && body.protocol !== 'tcp') {
+            sendJson(res, 400, {
+                error: "Only the 'tcp' protocol is supported by ScreenDeck",
+            })
+            return
+        }
+
+        const update: Record<string, unknown> = {}
+        if (typeof body.host === 'string') update.companionIP = body.host
+        if (typeof body.port === 'number') update.companionPort = body.port
+        if (typeof body.installationName === 'string')
+            update.installationName = body.installationName
+        if (typeof body.mdnsEnabled === 'boolean')
+            update.mdnsEnabled = body.mdnsEnabled
+
+        applyCompanionConnectionSettings(update)
+
+        sendJson(res, 200, getConfig())
+        return
+    }
+
+    sendJson(res, 404, { error: 'Not found' })
+}
+
+export function startRestServer() {
+    if (!store.get('restEnabled', true)) return
+    if (server) return
+
+    const port = store.get('restPort', 9999) as number
+
+    server = http.createServer((req, res) => {
+        handleRequest(req, res).catch((err) => {
+            console.error('[RestServer] Unhandled error:', err)
+            sendJson(res, 400, { error: 'Internal error' })
+        })
+    })
+
+    server.on('error', (err) => {
+        console.error('[RestServer] Failed to start:', err)
+        server = null
+    })
+
+    server.listen(port, '0.0.0.0', () => {
+        console.log(`[RestServer] Listening on 0.0.0.0:${port}`)
+    })
+}
+
+export function stopRestServer() {
+    if (server) {
+        server.close()
+        server = null
+    }
+}
+
+let restartTimer: NodeJS.Timeout | undefined
+function debouncedRestart() {
+    if (restartTimer) clearTimeout(restartTimer)
+    restartTimer = setTimeout(() => {
+        stopRestServer()
+        startRestServer()
+    }, 50)
+}
+
+// Restart the server whenever a relevant setting changes (e.g. from the
+// Settings UI or the REST /config route itself), so a live toggle/port
+// change takes effect immediately without an app restart.
+export function watchRestServerSettings() {
+    store.onDidChange('restEnabled', debouncedRestart)
+    store.onDidChange('restPort', debouncedRestart)
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -186,6 +186,36 @@ export function createSatellite() {
         })
 }
 
+// Applies a settings update that may include a new Companion IP/port,
+// reconnecting the satellite client if either actually changed. Shared by
+// the `saveSettings` IPC handler (Settings UI) and the mDNS/REST remote
+// config server (#4), so both paths trigger a reconnect the same way.
+export function applyCompanionConnectionSettings(
+    newSettings: Record<string, unknown>
+) {
+    const previousIP = store.get('companionIP', '127.0.0.1')
+    const previousPort = store.get('companionPort', 16622)
+
+    store.set(newSettings)
+
+    const newIP = newSettings.companionIP ?? previousIP
+    const newPort = newSettings.companionPort ?? previousPort
+
+    if (newIP !== previousIP || newPort !== previousPort) {
+        console.log('Companion IP or port changed, restarting connection...')
+
+        if (global.satelliteClient) {
+            global.satelliteClient.disconnect()
+            global.satelliteClient = null
+        }
+
+        // Wait briefly, then reconnect with the new IP/port
+        setTimeout(() => {
+            createSatellite()
+        }, 500)
+    }
+}
+
 // ===========================
 // Profile Management
 // ===========================

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10c0
 
 "7zip-bin@npm:~5.2.0":
@@ -206,6 +206,24 @@ __metadata:
     "@jridgewell/resolve-uri": "npm:^3.0.3"
     "@jridgewell/sourcemap-codec": "npm:^1.4.10"
   checksum: 10c0/fa425b606d7c7ee5bfa6a31a7b050dd5814b4082f318e0e4190f991902181b4330f43f4805db1dd4f2433fd0ed9cc7a7b9c2683f1deeab1df1b0a98b1e24055b
+  languageName: node
+  linkType: hard
+
+"@julusian/bonjour-service@npm:^1.4.3":
+  version: 1.4.3
+  resolution: "@julusian/bonjour-service@npm:1.4.3"
+  dependencies:
+    dns-packet: "npm:^5.2.2"
+    fast-deep-equal: "npm:^3.1.3"
+    thunky: "npm:^1.0.2"
+  checksum: 10c0/011f778a62cf59c4579063424fe63345b80ad90161a990d158e45f6a4243fc633ea2695a09509f4b5e321e3a26166c71614785fb466a2d0d85b87316a0ae24c9
+  languageName: node
+  linkType: hard
+
+"@leichtgewicht/ip-codec@npm:^2.0.1":
+  version: 2.0.5
+  resolution: "@leichtgewicht/ip-codec@npm:2.0.5"
+  checksum: 10c0/14a0112bd59615eef9e3446fea018045720cd3da85a98f801a685a818b0d96ef2a1f7227e8d271def546b2e2a0fe91ef915ba9dc912ab7967d2317b1a051d66b
   languageName: node
   linkType: hard
 
@@ -1382,6 +1400,15 @@ __metadata:
   bin:
     dmg-license: bin/dmg-license.js
   conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"dns-packet@npm:^5.2.2":
+  version: 5.6.1
+  resolution: "dns-packet@npm:5.6.1"
+  dependencies:
+    "@leichtgewicht/ip-codec": "npm:^2.0.1"
+  checksum: 10c0/8948d3d03063fb68e04a1e386875f8c3bcc398fc375f535f2b438fad8f41bf1afa6f5e70893ba44f4ae884c089247e0a31045722fa6ff0f01d228da103f1811d
   languageName: node
   linkType: hard
 
@@ -3168,6 +3195,7 @@ __metadata:
   resolution: "screendeck@workspace:."
   dependencies:
     "@electron/notarize": "npm:^2.5.0"
+    "@julusian/bonjour-service": "npm:^1.4.3"
     "@types/electron": "npm:^1.6.12"
     "@types/node": "npm:^22.15.29"
     "@types/semver": "npm:^7.7.0"
@@ -3519,6 +3547,13 @@ __metadata:
     async-exit-hook: "npm:^2.0.1"
     fs-extra: "npm:^10.0.0"
   checksum: 10c0/70e441909097346a930ae02278df9b0133cd02dddf0b49e5ddaade735fef1410a50a448a2a812106f97c045294c99cc19f26943eb88f1d728d41fbc445a40298
+  languageName: node
+  linkType: hard
+
+"thunky@npm:^1.0.2":
+  version: 1.1.0
+  resolution: "thunky@npm:1.1.0"
+  checksum: 10c0/369764f39de1ce1de2ba2fa922db4a3f92e9c7f33bcc9a713241bc1f4a5238b484c17e0d36d1d533c625efb00e9e82c3e45f80b47586945557b45abb890156d2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
ScreenDeck plays the same architectural role as Bitfocus's own [companion-satellite](https://github.com/bitfocus/companion-satellite) reference app (a client that dials out to a Companion server's satellite TCP port). I pulled that project's actual source (`mdnsAnnouncer.ts`, `config.ts`, `openapi.yaml`) to make this compatible with Companion's existing **Surfaces > Outbound > Discover** UI out of the box, rather than inventing a new protocol:

- **mDNS announcement**: advertises this ScreenDeck install as `_companion-satellite._tcp` via `@julusian/bonjour-service` — same library, service type, and TXT record shape the reference app uses.
- **REST config server**: implements the `/status`, `GET /config`, `POST /config` routes from companion-satellite's own `openapi.yaml`, so once Companion discovers a ScreenDeck install via mDNS, it can also **push a new Companion host/port to it**, not just see that it exists.
- New global settings: `installationName`, `mdnsEnabled`, `restEnabled`, `restPort` — defaults mirror the reference app's own defaults (all **on by default**, `restPort` 9999), confirmed with the maintainer since this does mean an unauthenticated local HTTP config endpoint, matching a known tradeoff the reference project already makes (not a new risk introduced here — called out in Settings UI copy too).
- New "Discovery & Remote Configuration" section in Settings, saved through the existing `saveSettings` IPC call — no preload/IPC changes needed.
- Extracted the "did the Companion IP/port change → reconnect" logic that used to live inline in the `saveSettings` handler into a shared `applyCompanionConnectionSettings()` helper (`src/utils.ts`), so both the Settings UI and the new `POST /config` route trigger a reconnect the same way.
- ScreenDeck only supports `'tcp'` mode today (a `Ws` client class exists in `client-implementations.ts` but isn't wired up anywhere), so `POST /config` rejects a `'ws'` protocol request with 400 — not a new limitation, just not exposing something that doesn't work yet.

Fixes #4

## Test plan
- [x] `tsc` build clean
- [x] JS syntax check (`node -c`) on modified `public/*.js` clean
- [x] `electronAPI` vs `preload.ts` cross-check clean
- [x] Live-launched against a real running Companion server; confirmed `GET /status` reflects live connection state (`connected`, `companionVersion`, `companionApiVersion`)
- [x] `GET /config` / `POST /config` round-trip verified with `curl`: rejects `protocol: 'ws'` with 400; a host/port change triggers an actual disconnect+reconnect (confirmed in app logs) and persists; a non-connection field (e.g. `installationName`) does *not* spuriously reconnect
- [x] Toggling `restEnabled` off/on via `saveSettings` (simulating the Settings UI) actually stops/restarts the HTTP listener, confirmed via `curl` connection failure/success
- [x] Confirmed the mDNS advertisement is live on the wire with `dns-sd -B _companion-satellite._tcp` and `dns-sd -L`, matching the configured install name, port, and `restEnabled` TXT record exactly
- [ ] Actually discovering and remotely configuring this ScreenDeck instance from a real Companion server's Surfaces > Outbound "Discover" UI — this environment has no way to run/drive a full Companion server instance's admin UI, so the REST contract match and raw mDNS broadcast were verified directly, but the full Companion-side round trip is worth a manual check on your end