### PR TITLE
Document the two distinct per-key store schemas

### DIFF
--- a/src/ipcHandlers.ts
+++ b/src/ipcHandlers.ts
@@ -445,6 +445,12 @@ export function initializeIpcHandlers() {
     // Handle assignHotkey - the payload is a HotkeyBinding plus the chosen
     // hotkey string, covering per-key hotkeys as well as the "show/hide all"
     // and "show/hide one device" app-level hotkeys (issue #38)
+    // Note: `device.<id>.keys` (plural) stores only `.hotkey` per index and is
+    // distinct from `device.<id>.key.<idx>` (singular, dot-per-field) used for
+    // isEncoder/stepSize/isSticky in getKeyConfig/updateKeyConfig above. Some
+    // older stores may have a stray `isEncoder` under `keys[idx]` left over
+    // from an earlier schema; it's never read and is preserved as-is by the
+    // spread below, not written by this handler.
     ipcMain.handle('assignHotkey', (_event, { hotkey, ...context }) => {
         let success = false
 


### PR DESCRIPTION
## Summary
Small documentation-only follow-up from a drive-by finding: `device.<id>.keys` (plural — hotkey-only) and `device.<id>.key.<idx>` (singular — encoder config: `isEncoder`/`stepSize`/`isSticky`) are two unrelated schemas with confusingly similar names in `src/ipcHandlers.ts`.

Investigated a stray `isEncoder` field that showed up in the plural `keys` schema in an older store — confirmed no live code path actually writes `isEncoder`/`stepSize`/`isSticky` into that schema, so it's just dead data from an earlier version, not an active bug. Added a comment clarifying the split so this doesn't cause confusion again.

No behavior change.

## Test plan
- Comment-only change; `tsc` build unaffected.